### PR TITLE
audit: defensive remediation — fail-closed gates, patch-engine integrity, resource bounds, data-layer parity

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -100,7 +100,27 @@ jobs:
         run: cargo install cargo-fuzz --locked
       - name: Short fuzz each target
         working-directory: fuzz
+        # A crash MUST fail the step (the job stays continue-on-error, so it
+        # will not block CI, but the red X is what makes a finding visible).
+        # Previously `|| true` swallowed even crashes.
         run: |
+          status=0
           for t in command_ast path_symlink patch_anchors unified_diff protobuf_public mcp_tool_schemas provider_projection context_manifests policy redaction_parsers archive_notebook; do
-            cargo fuzz run "$t" -- -max_total_time=20 || true
+            cargo fuzz run "$t" -- -max_total_time=20 || status=1
           done
+          exit $status
+  kernel-mini-supply-chain:
+    name: cargo-deny (kernel mini workspace)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb
+        with:
+          toolchain: stable
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+      - name: Scan advisories/licenses/bans/sources for the privileged mini-service
+        # The mini-service is its own Cargo workspace with its own lockfile;
+        # the root `cargo deny check` never sees its dependency graph.
+        working-directory: mini-services/terminus-kernel
+        run: cargo deny check

--- a/crates/terminus-egress/src/broker.rs
+++ b/crates/terminus-egress/src/broker.rs
@@ -9,7 +9,7 @@ use crate::{EgressError, EgressProxy};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpStream, UnixListener, UnixStream};
 
 const MAX_HANDSHAKE_BYTES: usize = 4 * 1024;

--- a/crates/terminus-egress/src/broker.rs
+++ b/crates/terminus-egress/src/broker.rs
@@ -241,7 +241,7 @@ where
 mod tests {
     use super::*;
     use crate::{DestinationPolicy, EgressPolicy, RateLimit};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
     use tokio::net::TcpListener;
 
     fn localhost_policy(deny_private_ips: bool, port: u16) -> EgressPolicy {

--- a/crates/terminus-extension-runtime/src/process_host.rs
+++ b/crates/terminus-extension-runtime/src/process_host.rs
@@ -100,28 +100,68 @@ impl ProcessExtensionHost {
             .stderr(Stdio::piped())
             .spawn()?;
 
-        {
-            let Some(stdin) = child.stdin.as_mut() else {
-                return Err(ExtensionError::Denied("stdin unavailable".into()));
-            };
-            let line = serde_json::to_string(request)?;
-            stdin.write_all(line.as_bytes())?;
-            stdin.write_all(b"\n")?;
-        }
+        // Write stdin from a worker thread: `write_all` parks while the child
+        // refuses to read, and a request larger than the pipe buffer would
+        // otherwise block before the wall-clock loop ever runs, making the
+        // timeout unenforceable. The channel lets us bound the wait; killing
+        // the child breaks the pipe and releases the writer.
+        let line = serde_json::to_string(request)?;
+        let Some(mut stdin) = child.stdin.take() else {
+            return Err(ExtensionError::Denied("stdin unavailable".into()));
+        };
+        let (stdin_done_tx, stdin_done_rx) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            let result = (|| -> std::io::Result<()> {
+                stdin.write_all(line.as_bytes())?;
+                stdin.write_all(b"\n")?;
+                Ok(())
+            })();
+            // Dropping stdin closes the pipe so the child sees EOF.
+            let _ = stdin_done_tx.send(());
+            result
+        });
+
+        // Drain stdout on another thread so a chatty child cannot fill the
+        // 64 KiB pipe and wedge itself while we are still in try_wait; the
+        // reader stops buffering one byte past the cap instead of reading
+        // everything first.
+        let max_output = self.limits.max_output_bytes;
+        let stdout_rx = child.stdout.take().map(|out| {
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let mut buf: Vec<u8> = Vec::new();
+                let mut overflowed = false;
+                let mut reader = out;
+                let mut chunk = [0u8; 8192];
+                loop {
+                    match reader.read(&mut chunk) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            buf.extend_from_slice(&chunk[..n]);
+                            if buf.len() > max_output {
+                                overflowed = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                let _ = tx.send((buf, overflowed));
+            });
+            rx
+        });
 
         let timeout = self.limits.wall_clock;
         let start = std::time::Instant::now();
+        let mut timed_out = false;
         loop {
             match child.try_wait() {
                 Ok(Some(_status)) => break,
                 Ok(None) => {
                     if start.elapsed() > timeout {
+                        timed_out = true;
                         let _ = child.kill();
                         let _ = child.wait();
-                        return Err(ExtensionError::Denied(format!(
-                            "extension timed out after {}ms",
-                            timeout.as_millis()
-                        )));
+                        break;
                     }
                     std::thread::sleep(Duration::from_millis(10));
                 }
@@ -129,14 +169,37 @@ impl ProcessExtensionHost {
             }
         }
 
-        let mut stdout = Vec::new();
-        if let Some(mut out) = child.stdout.take() {
-            let _ = out.read_to_end(&mut stdout);
+        // The child is gone or its pipes will close shortly; both worker
+        // threads finish bounded work from here. Give them a short grace
+        // period so a stuck writer/reader cannot hang this host forever.
+        let grace = Duration::from_secs(5);
+        let _ = stdin_done_rx.recv_timeout(grace);
+        if writer.is_finished() {
+            let _ = writer.join();
         }
-        if stdout.len() > self.limits.max_output_bytes {
+        let stdout = match stdout_rx {
+            Some(rx) => match rx.recv_timeout(grace) {
+                Ok((buf, overflowed)) => {
+                    if overflowed {
+                        return Err(ExtensionError::Denied(format!(
+                            "extension output exceeded {} bytes",
+                            self.limits.max_output_bytes
+                        )));
+                    }
+                    buf
+                }
+                Err(_) => {
+                    return Err(ExtensionError::Denied(
+                        "extension stdout did not close".into(),
+                    ))
+                }
+            },
+            None => Vec::new(),
+        };
+        if timed_out {
             return Err(ExtensionError::Denied(format!(
-                "extension output exceeded {} bytes",
-                self.limits.max_output_bytes
+                "extension timed out after {}ms",
+                timeout.as_millis()
             )));
         }
 

--- a/crates/terminus-extension-runtime/src/process_host.rs
+++ b/crates/terminus-extension-runtime/src/process_host.rs
@@ -103,51 +103,68 @@ impl ProcessExtensionHost {
         // Write stdin from a worker thread: `write_all` parks while the child
         // refuses to read, and a request larger than the pipe buffer would
         // otherwise block before the wall-clock loop ever runs, making the
-        // timeout unenforceable. The channel lets us bound the wait; killing
-        // the child breaks the pipe and releases the writer.
+        // timeout unenforceable. The channel carries the write result so an
+        // early-closed stdin is not silently ignored. Fallible spawn keeps
+        // thread-exhaustion from panicking the host.
         let line = serde_json::to_string(request)?;
         let Some(mut stdin) = child.stdin.take() else {
             return Err(ExtensionError::Denied("stdin unavailable".into()));
         };
-        let (stdin_done_tx, stdin_done_rx) = std::sync::mpsc::channel();
-        let writer = std::thread::spawn(move || {
-            let result = (|| -> std::io::Result<()> {
-                stdin.write_all(line.as_bytes())?;
-                stdin.write_all(b"\n")?;
-                Ok(())
-            })();
-            // Dropping stdin closes the pipe so the child sees EOF.
-            let _ = stdin_done_tx.send(());
-            result
-        });
+        let writer = std::thread::Builder::new()
+            .name("ext-stdin-writer".into())
+            .spawn(move || {
+                let result = (|| -> std::io::Result<()> {
+                    stdin.write_all(line.as_bytes())?;
+                    stdin.write_all(b"\n")?;
+                    Ok(())
+                })();
+                // Dropping stdin closes the pipe so the child sees EOF.
+                result
+            });
+        let writer = match writer {
+            Ok(handle) => handle,
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(ExtensionError::Denied(format!(
+                    "failed to start stdin writer: {e}"
+                )));
+            }
+        };
 
         // Drain stdout on another thread so a chatty child cannot fill the
         // 64 KiB pipe and wedge itself while we are still in try_wait; the
-        // reader stops buffering one byte past the cap instead of reading
-        // everything first.
+        // reader stops at the cap instead of buffering past it.
         let max_output = self.limits.max_output_bytes;
         let stdout_rx = child.stdout.take().map(|out| {
             let (tx, rx) = std::sync::mpsc::channel();
-            std::thread::spawn(move || {
-                let mut buf: Vec<u8> = Vec::new();
-                let mut overflowed = false;
-                let mut reader = out;
-                let mut chunk = [0u8; 8192];
-                loop {
-                    match reader.read(&mut chunk) {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) => {
-                            buf.extend_from_slice(&chunk[..n]);
-                            if buf.len() > max_output {
-                                overflowed = true;
-                                break;
+            let spawned = std::thread::Builder::new()
+                .name("ext-stdout-reader".into())
+                .spawn(move || {
+                    let mut buf: Vec<u8> = Vec::with_capacity(max_output.min(64 * 1024));
+                    let mut overflowed = false;
+                    let mut reader = out;
+                    let mut chunk = [0u8; 8192];
+                    loop {
+                        match reader.read(&mut chunk) {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => {
+                                // Copy only up to the remaining capacity so
+                                // the cap is enforced exactly, not one chunk
+                                // late.
+                                let remaining = max_output.saturating_sub(buf.len());
+                                if n > remaining {
+                                    buf.extend_from_slice(&chunk[..remaining]);
+                                    overflowed = true;
+                                    break;
+                                }
+                                buf.extend_from_slice(&chunk[..n]);
                             }
                         }
                     }
-                }
-                let _ = tx.send((buf, overflowed));
-            });
-            rx
+                    let _ = tx.send((buf, overflowed));
+                });
+            spawned.map(|_handle| rx)
         });
 
         let timeout = self.limits.wall_clock;
@@ -168,17 +185,27 @@ impl ProcessExtensionHost {
                 Err(e) => return Err(ExtensionError::Io(e)),
             }
         }
+        // The child has exited (or was killed); its stdin pipe is broken and
+        // the writer's outcome is final.
+        let write_result = writer.join().ok();
 
-        // The child is gone or its pipes will close shortly; both worker
-        // threads finish bounded work from here. Give them a short grace
-        // period so a stuck writer/reader cannot hang this host forever.
-        let grace = Duration::from_secs(5);
-        let _ = stdin_done_rx.recv_timeout(grace);
-        if writer.is_finished() {
-            let _ = writer.join();
-        }
+        // Bound the post-exit drain so the host always returns: normally the
+        // reader sees EOF immediately, but a forked descendant that inherited
+        // the stdout pipe can hold it open, so never wait beyond the
+        // remaining wall-clock budget plus a small fixed allowance.
+        let elapsed = start.elapsed();
+        let drain_budget = if elapsed < timeout {
+            (timeout - elapsed) + Duration::from_secs(2)
+        } else {
+            Duration::from_secs(2)
+        };
         let stdout = match stdout_rx {
-            Some(rx) => match rx.recv_timeout(grace) {
+            Some(Err(spawn_err)) => {
+                return Err(ExtensionError::Denied(format!(
+                    "failed to start stdout reader: {spawn_err}"
+                )));
+            }
+            Some(Ok(rx)) => match rx.recv_timeout(drain_budget) {
                 Ok((buf, overflowed)) => {
                     if overflowed {
                         return Err(ExtensionError::Denied(format!(
@@ -201,6 +228,20 @@ impl ProcessExtensionHost {
                 "extension timed out after {}ms",
                 timeout.as_millis()
             )));
+        }
+        // A failed stdin write means the extension never received the request;
+        // treating whatever it printed as a response would be fabrication.
+        match write_result {
+            Some(Ok(())) => {}
+            other => {
+                return Err(ExtensionError::Denied(format!(
+                    "extension did not accept the request: {}",
+                    match other {
+                        Some(Err(e)) => e.to_string(),
+                        _ => "writer lost".to_string(),
+                    }
+                )));
+            }
         }
 
         let text = String::from_utf8_lossy(&stdout);

--- a/docs/generated/inventory.md
+++ b/docs/generated/inventory.md
@@ -15,7 +15,7 @@ A declared test is not a passing run. Executed-test evidence lives in CI
 | Client apps | 4 | directories in apps/ |
 | External harness adapters | 7 | directories in adapters/ |
 | Mini-services | 2 | directories in mini-services/ |
-| Declared Rust tests | 408 | `#[test]` + `#[tokio::test]` occurrences in crates/** (excl. generated) |
+| Declared Rust tests | 409 | `#[test]` + `#[tokio::test]` occurrences in crates/** (excl. generated) |
 | TypeScript test files | 100 | `*.test.{ts,tsx}` in packages/ + apps/ |
 | Declared TypeScript test blocks | 825 | `test(/it(` occurrences in those files |
 | Declared Python tests | 243 | `def test_*` in python/** |

--- a/justfile
+++ b/justfile
@@ -91,6 +91,8 @@ nextest:
 # Lint + test the kernel HTTP mini-service, which intentionally sits outside
 # the root Cargo workspace (SPEC §42.5 boundary). The root `cargo clippy
 # --workspace` does not cover it, so it is checked explicitly here and in CI.
+# cargo-deny runs WITHOUT the advisories DB update so this stays usable
+# offline; nightly CI scans advisories for this workspace.
 kernel-mini-check:
     #!/usr/bin/env bash
     set -eu
@@ -98,6 +100,7 @@ kernel-mini-check:
     cargo fmt -- --check
     cargo clippy --all-targets
     cargo test
+    cargo deny check bans licenses sources
 
 # Architecture boundary checks (SPEC §42.5).
 boundary-check:

--- a/mini-services/terminus-control/src/index.ts
+++ b/mini-services/terminus-control/src/index.ts
@@ -119,8 +119,8 @@ import type {
   ModelKey,
   Rfc3339Timestamp,
   TokenCount,
-} from "../../../packages/domain/src/index.ts";
-import { generateUuid7 } from "../../../packages/domain/src/index.ts";
+} from "@terminus/domain";
+import { generateUuid7 } from "@terminus/domain";
 import {
   authorizationInstanceSchema,
   artifactUriSchema,
@@ -200,8 +200,8 @@ import {
   type NodeRun,
   type TaskContractV2,
   type TaskV2,
-} from "../../../packages/domain/src/index.ts";
-import { ARP_V2_COMMAND_TYPES, ARP_V2_EVENT_TYPES } from "../../../packages/runtime-protocol/src/index.ts";
+} from "@terminus/domain";
+import { ARP_V2_COMMAND_TYPES, ARP_V2_EVENT_TYPES } from "@terminus/runtime-protocol";
 import { z } from "zod";
 import {
   checkpointContentSchema,

--- a/mini-services/terminus-control/src/verification-runtime.ts
+++ b/mini-services/terminus-control/src/verification-runtime.ts
@@ -16,7 +16,7 @@ import type {
   AcceptanceCriterion,
   Rfc3339Timestamp,
   Uuid7,
-} from "../../../packages/domain/src/index.ts";
+} from "@terminus/domain";
 import {
   InMemoryVerificationStore,
   VerificationEngine,
@@ -28,7 +28,7 @@ import {
   type ClaimEvidenceGraph,
   type VerificationAttemptRecord,
   type PredicateType,
-} from "../../../packages/verification/src/index.ts";
+} from "@terminus/verification";
 import type { KernelUdsClients } from "./kernel-uds.js";
 import type {
   ProcessEvent,

--- a/mini-services/terminus-kernel/Cargo.toml
+++ b/mini-services/terminus-kernel/Cargo.toml
@@ -28,23 +28,23 @@ panic = { level = "deny", priority = 1 }
 
 [dependencies]
 # Terminus kernel crates (path deps to the workspace crates).
-terminus-kernel = { path = "../../crates/terminus-kernel" }
-terminus-kernel-protocol = { path = "../../crates/terminus-kernel-protocol" }
-terminus-artifacts = { path = "../../crates/terminus-artifacts" }
-terminus-fs = { path = "../../crates/terminus-fs" }
-terminus-policy = { path = "../../crates/terminus-policy" }
-terminus-sandbox = { path = "../../crates/terminus-sandbox" }
-terminus-sandbox-linux = { path = "../../crates/terminus-sandbox-linux" }
-terminus-process = { path = "../../crates/terminus-process" }
-terminus-jobs = { path = "../../crates/terminus-jobs" }
-terminus-patch = { path = "../../crates/terminus-patch" }
-terminus-secrets = { path = "../../crates/terminus-secrets" }
-terminus-connector = { path = "../../crates/terminus-connector" }
-terminus-egress = { path = "../../crates/terminus-egress" }
-terminus-code-intel = { path = "../../crates/terminus-code-intel" }
-terminus-extension-runtime = { path = "../../crates/terminus-extension-runtime" }
-terminus-git = { path = "../../crates/terminus-git" }
-terminus-authz = { path = "../../crates/terminus-authz" }
+terminus-kernel = { path = "../../crates/terminus-kernel", version = "0.1.0" }
+terminus-kernel-protocol = { path = "../../crates/terminus-kernel-protocol", version = "0.1.0" }
+terminus-artifacts = { path = "../../crates/terminus-artifacts", version = "0.1.0" }
+terminus-fs = { path = "../../crates/terminus-fs", version = "0.1.0" }
+terminus-policy = { path = "../../crates/terminus-policy", version = "0.1.0" }
+terminus-sandbox = { path = "../../crates/terminus-sandbox", version = "0.1.0" }
+terminus-sandbox-linux = { path = "../../crates/terminus-sandbox-linux", version = "0.1.0" }
+terminus-process = { path = "../../crates/terminus-process", version = "0.1.0" }
+terminus-jobs = { path = "../../crates/terminus-jobs", version = "0.1.0" }
+terminus-patch = { path = "../../crates/terminus-patch", version = "0.1.0" }
+terminus-secrets = { path = "../../crates/terminus-secrets", version = "0.1.0" }
+terminus-connector = { path = "../../crates/terminus-connector", version = "0.1.0" }
+terminus-egress = { path = "../../crates/terminus-egress", version = "0.1.0" }
+terminus-code-intel = { path = "../../crates/terminus-code-intel", version = "0.1.0" }
+terminus-extension-runtime = { path = "../../crates/terminus-extension-runtime", version = "0.1.0" }
+terminus-git = { path = "../../crates/terminus-git", version = "0.1.0" }
+terminus-authz = { path = "../../crates/terminus-authz", version = "0.1.0" }
 
 # HTTP stack.
 axum = { version = "0.7", features = ["json", "http1", "tokio"] }
@@ -76,7 +76,7 @@ nix = { version = "0.29", features = ["process"] }
 tonic = { version = "0.12", features = ["tls"] }
 prost = "0.13"
 prost-types = "0.13"
-terminus-remote = { path = "../../crates/terminus-remote" }
+terminus-remote = { path = "../../crates/terminus-remote", version = "0.1.0" }
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/mini-services/terminus-kernel/src/handlers/files.rs
+++ b/mini-services/terminus-kernel/src/handlers/files.rs
@@ -181,9 +181,7 @@ fn scan_directory(base: &std::path::Path) -> std::io::Result<DirectoryScan> {
         // Stream-hash small files in fixed-size chunks instead of loading
         // them whole: a multi-gigabyte file used to be fully resident before
         // hashing even started.
-        let hash = if kind == "file"
-            && size <= MAX_HASH_FILE_BYTES
-        {
+        let hash = if kind == "file" && size <= MAX_HASH_FILE_BYTES {
             hash_file_streaming(entry.path()).unwrap_or_default()
         } else {
             String::new()

--- a/mini-services/terminus-kernel/src/handlers/network.rs
+++ b/mini-services/terminus-kernel/src/handlers/network.rs
@@ -129,9 +129,21 @@ pub async fn request(
             "{scheme} scheme authorized but not relayed by this broker (TLS not supported here); no request was sent"
         ));
     } else if let Some(target_ip) = resolved_ips.first() {
+        // Bounded relay: an authorized-but-hostile destination used to be
+        // able to hang this handler forever (no connect/read deadline) and
+        // grow the response buffer without limit, exhausting connections and
+        // memory one request at a time.
+        const RELAY_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+        const RELAY_IO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        const MAX_RELAY_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
         let target_addr = std::net::SocketAddr::new(*target_ip, port);
-        match tokio::net::TcpStream::connect(target_addr).await {
-            Ok(mut stream) => {
+        let connect = tokio::time::timeout(
+            RELAY_CONNECT_TIMEOUT,
+            tokio::net::TcpStream::connect(target_addr),
+        )
+        .await;
+        match connect {
+            Ok(Ok(mut stream)) => {
                 use tokio::io::{AsyncReadExt, AsyncWriteExt};
                 let path = if url.path().is_empty() {
                     "/"
@@ -150,34 +162,58 @@ pub async fn request(
                     req.body.len(),
                     req.body
                 );
-                match stream.write_all(http_req.as_bytes()).await {
-                    Ok(()) => {
+                let write =
+                    tokio::time::timeout(RELAY_IO_TIMEOUT, stream.write_all(http_req.as_bytes()))
+                        .await;
+                match write {
+                    Ok(Ok(())) => {
                         bytes_relayed += http_req.len() as u64;
                         let mut resp_buf = Vec::new();
-                        match stream.read_to_end(&mut resp_buf).await {
-                            Ok(_) => {
-                                bytes_relayed += resp_buf.len() as u64;
-                                if !resp_buf.is_empty() {
-                                    body_out = String::from_utf8_lossy(&resp_buf).to_string();
-                                    status = body_out
-                                        .split_whitespace()
-                                        .nth(1)
-                                        .and_then(|s| s.parse::<u16>().ok())
-                                        .unwrap_or(0);
+                        loop {
+                            let mut chunk = [0u8; 16 * 1024];
+                            let read =
+                                tokio::time::timeout(RELAY_IO_TIMEOUT, stream.read(&mut chunk))
+                                    .await;
+                            match read {
+                                Ok(Ok(0)) | Err(_) => break,
+                                Ok(Ok(n)) => {
+                                    bytes_relayed += n as u64;
+                                    resp_buf.extend_from_slice(&chunk[..n]);
+                                    if resp_buf.len() > MAX_RELAY_RESPONSE_BYTES {
+                                        relay_note = Some(format!(
+                                            "relay response exceeded {MAX_RELAY_RESPONSE_BYTES} bytes and was truncated"
+                                        ));
+                                        break;
+                                    }
+                                }
+                                Ok(Err(e)) => {
+                                    relay_note = Some(format!("relay read failed: {e}"));
+                                    break;
                                 }
                             }
-                            Err(e) => {
-                                relay_note = Some(format!("relay read failed: {e}"));
-                            }
+                        }
+                        if !resp_buf.is_empty() {
+                            body_out = String::from_utf8_lossy(&resp_buf).to_string();
+                            status = body_out
+                                .split_whitespace()
+                                .nth(1)
+                                .and_then(|s| s.parse::<u16>().ok())
+                                .unwrap_or(0);
                         }
                     }
-                    Err(e) => {
+                    Ok(Err(e)) => {
                         relay_note = Some(format!("relay write failed: {e}"));
+                    }
+                    Err(_) => {
+                        relay_note = Some("relay write timed out".to_string());
                     }
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 relay_note = Some(format!("relay connect failed: {e}"));
+            }
+            Err(_) => {
+                relay_note = Some("relay connect timed out".to_string());
             }
         }
     } else {

--- a/mini-services/terminus-kernel/src/handlers/network.rs
+++ b/mini-services/terminus-kernel/src/handlers/network.rs
@@ -135,6 +135,8 @@ pub async fn request(
         // memory one request at a time.
         const RELAY_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
         const RELAY_IO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        // Absolute ceiling on the whole response phase.
+        const RELAY_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
         const MAX_RELAY_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
         let target_addr = std::net::SocketAddr::new(*target_ip, port);
         let connect = tokio::time::timeout(
@@ -169,25 +171,38 @@ pub async fn request(
                     Ok(Ok(())) => {
                         bytes_relayed += http_req.len() as u64;
                         let mut resp_buf = Vec::new();
+                        // One absolute deadline for the entire response phase:
+                        // per-read deadlines alone would let a peer trickle
+                        // bytes just under the idle timeout forever.
+                        let read_deadline = tokio::time::Instant::now() + RELAY_TOTAL_TIMEOUT;
                         loop {
                             let mut chunk = [0u8; 16 * 1024];
                             let read =
-                                tokio::time::timeout(RELAY_IO_TIMEOUT, stream.read(&mut chunk))
+                                tokio::time::timeout_at(read_deadline, stream.read(&mut chunk))
                                     .await;
                             match read {
-                                Ok(Ok(0)) | Err(_) => break,
+                                Ok(Ok(0)) => break,
                                 Ok(Ok(n)) => {
                                     bytes_relayed += n as u64;
-                                    resp_buf.extend_from_slice(&chunk[..n]);
-                                    if resp_buf.len() > MAX_RELAY_RESPONSE_BYTES {
+                                    // Clamp to the cap so retention never
+                                    // overshoots by one chunk.
+                                    let remaining =
+                                        MAX_RELAY_RESPONSE_BYTES.saturating_sub(resp_buf.len());
+                                    if n > remaining {
+                                        resp_buf.extend_from_slice(&chunk[..remaining]);
                                         relay_note = Some(format!(
                                             "relay response exceeded {MAX_RELAY_RESPONSE_BYTES} bytes and was truncated"
                                         ));
                                         break;
                                     }
+                                    resp_buf.extend_from_slice(&chunk[..n]);
                                 }
                                 Ok(Err(e)) => {
                                     relay_note = Some(format!("relay read failed: {e}"));
+                                    break;
+                                }
+                                Err(_) => {
+                                    relay_note = Some("relay response timed out".to_string());
                                     break;
                                 }
                             }

--- a/mini-services/terminus-kernel/src/main.rs
+++ b/mini-services/terminus-kernel/src/main.rs
@@ -28,9 +28,7 @@ use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
 use crate::auth::{cors_layer, require_bearer, require_capability_for_path};
-use crate::state::{
-    AppState, EXITED_PROCESS_RETENTION, PROCESS_JANITOR_INTERVAL,
-};
+use crate::state::{AppState, EXITED_PROCESS_RETENTION, PROCESS_JANITOR_INTERVAL};
 
 /// Loopback bootstrap port. Production uses the UDS transport; the env
 /// override keeps deterministic local harnesses isolated from other runs.

--- a/packages/terminus-kernel-client/src/generated-ts-proto/google/protobuf/timestamp.ts
+++ b/packages/terminus-kernel-client/src/generated-ts-proto/google/protobuf/timestamp.ts
@@ -102,16 +102,15 @@ export const protobufPackage = "google.protobuf";
  */
 export interface Timestamp {
   /**
-   * Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
-   * be between -315576000000 and 315576000000 inclusive (which corresponds to
-   * 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
+   * Represents seconds of UTC time since Unix epoch
+   * 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+   * 9999-12-31T23:59:59Z inclusive.
    */
   seconds: number;
   /**
-   * Non-negative fractions of a second at nanosecond resolution. This field is
-   * the nanosecond portion of the duration, not an alternative to seconds.
-   * Negative second values with fractions must still have non-negative nanos
-   * values that count forward in time. Must be between 0 and 999,999,999
+   * Non-negative fractions of a second at nanosecond resolution. Negative
+   * second values with fractions must still have non-negative nanos values
+   * that count forward in time. Must be from 0 to 999,999,999
    * inclusive.
    */
   nanos: number;


### PR DESCRIPTION
Authorized full-repo audit and remediation (branch `repo-audit/20260824T0000Z`, 5 commits on top of `d469ab4`; earlier audit commits already absorbed into main by the concurrent session).

## Fixes
- **Fail-open release gates closed** (`e3fae57` predecessor work + this branch): fuzz-smoke missing fixtures fail; soak fallback removed; corrupt findings register → `invalid_register`; release workflow fails fast when M12 evidence absent; container build required + pinned rust image; nightly fuzz crashes surface.
- **Supply chain**: cargo-deny now scans the kernel mini-workspace (its own lockfile was invisible to root gates); path deps versioned to satisfy `wildcards=deny`.
- **Patch engine integrity**: rollback restores pre-transaction state for same-path double edits; CRLF preserved; unified diffs verified line-by-line via strict parser (drifted hunks/EOF deletions/malformed headers rejected); non-UTF-8 rejected instead of lossy rewrite. 7/8 new tests fail on pristine main.
- **Resource bounds**: network relay deadlines + response cap; files/list entry caps + streaming hash; egress handshake capped during buffering; extension-host stdin/stdout can't block past wall-clock.
- **Correctness**: AsyncBufReadExt kept for broker tests (caught by full-workspace run); control-service imports via package entrypoints.

## Verification
- cargo workspace: 405 passed / 0 failed (63 suites); security suites green (capability_token_e2e 12, non_bypassability 20, policy_wiring 17, secret_canary_e2e 5)
- mini-service: fmt/clippy/test clean, deny bans/licenses/sources ok
- bun: 470 unit + 231 integration pass; all 3 tsc targets pass; lint 0 errors
- boundary-check, standalone-check, truth-check, codegen-check all pass

## Known residual risks (documented, deliberately deferred)
Event catalog / public-api registry / config spec drift are source-of-truth conflicts needing product decisions; proto mirror lacks descriptor-equivalence tests; dead generated TS client entangled with codegen pipeline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closed runtime and CI gates with bounded resource use across the kernel relay and extension host; align codegen with pinned tooling. Previously the relay had no deadlines and unbounded buffering, and the extension host could block past its wall‑clock timeout; now we enforce connect/IO/total-response timeouts, cap buffers with explicit truncation, propagate write/read failures, and uphold wall‑clock limits.

- Kernel HTTP relay: add connect and per-IO timeouts plus a 60s absolute response deadline; cap responses at 8 MiB with an explicit truncation note; parse status only from received bytes; surface write/read/timeout notes.
- Extension host: write stdin and drain stdout on worker threads with fallible spawns; enforce the wall‑clock timeout even if the child never reads; cap stdout during buffering and error exactly on overflow; propagate stdin write failures; bound post‑exit stdout drain by the remaining wall‑clock budget + 2s; surface timeouts with clear errors.
- CI/gates: nightly fuzz no longer uses `|| true`; a crash fails the step (job remains continue‑on‑error). Add a `cargo-deny` job that scans the kernel mini workspace. `just kernel-mini-check` now runs `cargo deny check` bans/licenses/sources offline.
- Supply chain: mini‑service path dependencies include `version` to satisfy `wildcards=deny`.
- TS control service: import from `@terminus/domain`, `@terminus/runtime-protocol`, and `@terminus/verification` instead of deep relative paths; no functional changes.
- Codegen: regenerate `packages/terminus-kernel-client` ts-proto `google/protobuf/timestamp.ts` with pinned `buf` 1.59 to match the pipeline; no functional changes.
- Tests/docs: keep `AsyncBufReadExt` in egress tests; declared Rust test count +1 (409).

- Rollout and migration
  - If you rely on relay responses larger than 8 MiB, update callers/tests to handle truncation or fetch data in smaller chunks.
  - If an extension produces very large stdout, expect an overflow error; adjust limits or reduce output.
  - Ensure nightly runners have `cargo-deny` available; no config changes required.

<sup>Written for commit ea61f8fe9464263644632097712dd643360c660a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ezzy1630/Terminus/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

