### PR TITLE
feat(provider): implement native OpenAI Responses and Anthropic Messages connectors

### DIFF
--- a/crates/terminus-kernel/src/services.rs
+++ b/crates/terminus-kernel/src/services.rs
@@ -270,6 +270,12 @@ impl KernelHandle {
                     grant_key.to_vec(),
                 )
                 .connector("opencode-gateway", terminus_connector::AuthStyle::Bearer)
+                .connector("openai-responses", terminus_connector::AuthStyle::Bearer)
+                .connector("openai-chat", terminus_connector::AuthStyle::Bearer)
+                .connector(
+                    "anthropic-messages",
+                    terminus_connector::AuthStyle::NamedHeader("x-api-key".into()),
+                )
                 .build();
                 ConnectorService::new(
                     Arc::new(broker),

--- a/docs/generated/inventory.md
+++ b/docs/generated/inventory.md
@@ -16,8 +16,8 @@ A declared test is not a passing run. Executed-test evidence lives in CI
 | External harness adapters | 7 | directories in adapters/ |
 | Mini-services | 2 | directories in mini-services/ |
 | Declared Rust tests | 409 | `#[test]` + `#[tokio::test]` occurrences in crates/** (excl. generated) |
-| TypeScript test files | 101 | `*.test.{ts,tsx}` in packages/ + apps/ |
-| Declared TypeScript test blocks | 833 | `test(/it(` occurrences in those files |
+| TypeScript test files | 103 | `*.test.{ts,tsx}` in packages/ + apps/ |
+| Declared TypeScript test blocks | 839 | `test(/it(` occurrences in those files |
 | Declared Python tests | 243 | `def test_*` in python/** |
 | ADRs | 44 | docs/decisions/ADR-*.md |
 | Runbooks | 15 | docs/runbooks/*.md |

--- a/packages/provider-anthropic/src/anthropic_messages.test.ts
+++ b/packages/provider-anthropic/src/anthropic_messages.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelKey, TokenCount, ContentHash, Uuid7 } from "@terminus/domain";
+import { micros } from "@terminus/domain";
+import type {
+  CanonicalRenderInput,
+  ContextFragment,
+  ModelCapabilitySnapshot,
+  ProviderCapabilitySnapshot,
+  ProviderToolSchema,
+} from "@terminus/provider-core";
+import {
+  AnthropicRenderer,
+  renderRequest,
+  decodeAnthropicMessagesStream,
+} from "./index.js";
+
+const DEFAULT_PROVIDER_CAPS: ProviderCapabilitySnapshot = {
+  providerId: "anthropic",
+  observedAt: "2026-08-24T00:00:00Z",
+  source: "test",
+  context: {
+    advertisedTokens: 200_000,
+    testedSafeTokens: 180_000,
+    roleSupport: ["system", "user", "assistant"],
+    imageInput: true,
+    toolCalling: true,
+    parallelToolCalls: true,
+    structuredOutput: true,
+  },
+  continuation: {
+    nativeId: false,
+    crossRequest: false,
+    compaction: false,
+    compatibilityKey: "anthropic-messages-v1",
+  },
+  caching: {
+    mode: "explicit_breakpoints",
+    exactPrefixRequired: true,
+    minimumTokens: 1024,
+    ttlOptions: ["5m"],
+    toolOrderSensitive: true,
+    usageReporting: true,
+  },
+  reasoning: {
+    supported: true,
+    budgetControl: true,
+    summaryAvailable: true,
+  },
+  economics: {
+    inputMicrosPerMillion: micros(3_000_000),
+    cachedInputMicrosPerMillion: micros(300_000),
+    outputMicrosPerMillion: micros(15_000_000),
+    reasoningAccounting: true,
+  },
+  reliability: {
+    toolCallSuccess: 0.95,
+    structuredOutputSuccess: 0.96,
+    editCohortSuccess: 0.90,
+    latencyPercentiles: { p50: 1200, p95: 4000, p99: 8000 },
+  },
+  policy: {
+    allowedConfidentiality: ["public", "workspace", "secret_adjacent", "secret"],
+    retentionMode: "30d",
+    region: "us-east-1",
+  },
+};
+
+const DEFAULT_MODEL_KEY = "anthropic/claude-3-5-sonnet" as ModelKey;
+
+const DEFAULT_MODEL_CAPS: ModelCapabilitySnapshot = {
+  modelKey: DEFAULT_MODEL_KEY,
+  providerId: "anthropic",
+  snapshot: DEFAULT_PROVIDER_CAPS,
+  observedAt: "2026-08-24T00:00:00Z",
+};
+
+const DUMMY_TOOL: ProviderToolSchema = {
+  id: "read",
+  version: "1.0.0",
+  summary: "Read file",
+  inputSchema: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+  resultSchema: { type: "object", properties: { content: { type: "string" } } },
+  sideEffectClass: "READ_ONLY",
+  requiredCapabilities: [],
+  trustLevel: "builtin",
+  maximumModelResultBytes: 4096,
+  maximumArtifactBytes: 1048576,
+  defaultTimeoutMs: 5000,
+  policyTags: [],
+};
+
+function mkFragment(id: string, kind: string, text: string): ContextFragment {
+  return {
+    id,
+    kind: kind as ContextFragment["kind"],
+    textContent: text,
+    contentRef: { uri: `artifact://${id}` as any, hash: `sha256:${id}` as ContentHash, mediaType: "text/plain", bytes: 100n as any },
+    source: { uri: `test://${id}`, producer: "test", producerVersion: "1.0", observedAt: "2026-08-24T00:00:00Z" as any, observedBy: "control", evidenceRefs: [] },
+    sourceVersion: null,
+    authority: 100,
+    priority: 1,
+    trust: "trusted",
+    confidentiality: "workspace",
+    injectionRisk: "none",
+    exactness: "exact",
+    scope: { workspaceId: null, sessionId: null, taskId: null, pathPatterns: [] },
+    freshness: { observedAt: "2026-08-24T00:00:00Z" as any, sourceVersion: null, stale: false, staleReason: null },
+    dependencies: [],
+    invalidation: [],
+    estimatedTokens: { [DEFAULT_MODEL_KEY]: 25 } as any,
+    selectionFeatures: { relevance: 1, novelty: 1, coverage: 1, uncertaintyReduction: 1, riskReduction: 1, modelCompatibility: 1, redundancyPenalty: 0, injectionPenalty: 0 },
+  };
+}
+
+describe("Anthropic Messages Connector", () => {
+  test("renders valid Anthropic Messages API request body with thinking and cache control", async () => {
+    const input: CanonicalRenderInput = {
+      provider: DEFAULT_PROVIDER_CAPS,
+      model: DEFAULT_MODEL_CAPS,
+      manifestId: "01934567-89ab-7000-8000-cdef01234567" as Uuid7,
+      fragments: [
+        mkFragment("f1", "authority", "System instructions."),
+        mkFragment("f2", "user_attachment", "Please read index.ts"),
+      ],
+      toolSchemas: [DUMMY_TOOL],
+      cachePlan: { stablePrefixHash: `sha256:${"0".repeat(64)}` as ContentHash, breakpoints: [0] },
+      continuationId: null,
+      outputProfile: "terse",
+      reasoningReserveTokens: 2048n as TokenCount,
+      outputReserveTokens: 4096n as TokenCount,
+      hardInputLimit: 100000n as TokenCount,
+      signal: null,
+    };
+
+    const rendered = await renderRequest(input);
+    const body = rendered.body as Record<string, unknown>;
+
+    expect(body.model).toBe("anthropic/claude-3-5-sonnet");
+    expect(body.stream).toBe(true);
+    expect(body.max_tokens).toBe(4096);
+
+    const system = body.system as Array<{ type: string; text: string; cache_control?: { type: string } }>;
+    expect(system).toHaveLength(1);
+    expect(system[0]!.text).toBe("System instructions.");
+    expect(system[0]!.cache_control?.type).toBe("ephemeral");
+
+    const thinking = body.thinking as { type: string; budget_tokens: number };
+    expect(thinking).toBeDefined();
+    expect(thinking.type).toBe("enabled");
+    expect(thinking.budget_tokens).toBe(2048);
+
+    const tools = body.tools as Array<{ name: string; input_schema: unknown }>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0]!.name).toBe("read");
+    expect(tools[0]!.input_schema).toBeDefined();
+
+    const messages = body.messages as Array<{ role: string; content: string }>;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.role).toBe("user");
+    expect(messages[0]!.content).toBe("Please read index.ts");
+  });
+
+  test("renders multi-turn tool interaction with linked tool_use and tool_result blocks", async () => {
+    const input: CanonicalRenderInput = {
+      provider: DEFAULT_PROVIDER_CAPS,
+      model: DEFAULT_MODEL_CAPS,
+      manifestId: "01934567-89ab-7000-8000-cdef01234568" as Uuid7,
+      fragments: [
+        mkFragment("f1", "authority", "System instructions."),
+        mkFragment("f2", "user_attachment", "Read index.ts"),
+        mkFragment("f3", "recent_episode", JSON.stringify({
+          protocol: "terminus.tool-call.v1",
+          provider_call_id: "toolu_123",
+          tool_name: "read",
+          arguments: { path: "index.ts" },
+        })),
+        mkFragment("f4", "tool_result", JSON.stringify({
+          protocol: "terminus.tool-result.v1",
+          provider_call_id: "toolu_123",
+          tool_name: "read",
+          result: "console.log('hello');",
+          is_error: false,
+        })),
+      ],
+      toolSchemas: [DUMMY_TOOL],
+      cachePlan: { stablePrefixHash: `sha256:${"0".repeat(64)}` as ContentHash, breakpoints: [] },
+      continuationId: null,
+      outputProfile: "terse",
+      reasoningReserveTokens: 0n as TokenCount,
+      outputReserveTokens: 2048n as TokenCount,
+      hardInputLimit: 100000n as TokenCount,
+      signal: null,
+    };
+
+    const rendered = await renderRequest(input);
+    const body = rendered.body as Record<string, unknown>;
+    const messages = body.messages as Array<{ role: string; content: unknown }>;
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0]!.role).toBe("user");
+    expect(messages[0]!.content).toBe("Read index.ts");
+
+    expect(messages[1]!.role).toBe("assistant");
+    const assistantContent = messages[1]!.content as Array<{ type: string; id: string; name: string; input: unknown }>;
+    expect(assistantContent[0]!.type).toBe("tool_use");
+    expect(assistantContent[0]!.id).toBe("toolu_123");
+    expect(assistantContent[0]!.name).toBe("read");
+
+    expect(messages[2]!.role).toBe("user");
+    const userContent = messages[2]!.content as Array<{ type: string; tool_use_id: string; content: string; is_error?: boolean }>;
+    expect(userContent[0]!.type).toBe("tool_result");
+    expect(userContent[0]!.tool_use_id).toBe("toolu_123");
+    expect(userContent[0]!.content).toBe("console.log('hello');");
+  });
+
+  test("streams and decodes Anthropic Messages API SSE frames with thinking and cache usage", async () => {
+    async function* anthropicSseGenerator(): AsyncIterable<string> {
+      yield "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"usage\":{\"input_tokens\":150,\"cache_read_input_tokens\":100,\"cache_creation_input_tokens\":50}}}\n\n";
+      yield "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n";
+      yield "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Analyzing code structure...\"}}\n\n";
+      yield "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n";
+      yield "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_abc\",\"name\":\"read\",\"input\":{}}}\n\n";
+      yield "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\": \\\"src/main.rs\\\"}\"}}\n\n";
+      yield "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n";
+      yield "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":45}}\n\n";
+      yield "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+    }
+
+    const chunks: any[] = [];
+    for await (const chunk of decodeAnthropicMessagesStream(anthropicSseGenerator())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toEqual({ kind: "text", reasoning: "Analyzing code structure..." });
+    expect(chunks[1]).toEqual({
+      kind: "tool_call",
+      toolCall: {
+        toolCallId: "toolu_abc",
+        toolName: "read",
+        arguments: { path: "src/main.rs" },
+      },
+    });
+    expect(chunks[2]).toEqual({
+      kind: "done",
+      usage: {
+        inputTokens: 150n as TokenCount,
+        cachedInputTokens: 100n as TokenCount,
+        cacheWriteTokens: 50n as TokenCount,
+        outputTokens: 45n as TokenCount,
+        reasoningTokens: 0n as TokenCount,
+        toolSchemaTokens: 0n as TokenCount,
+        latencyMs: 0,
+        timeToFirstTokenMs: null,
+      },
+    });
+  });
+});

--- a/packages/provider-anthropic/src/index.ts
+++ b/packages/provider-anthropic/src/index.ts
@@ -52,6 +52,7 @@ export interface AnthropicToolSchema {
   readonly name: string;
   readonly description: string;
   readonly input_schema: Readonly<Record<string, unknown>>;
+  readonly cache_control?: { readonly type: "ephemeral" } | undefined;
 }
 
 export interface AnthropicRequestBody {
@@ -248,17 +249,21 @@ function renderMessages(input: CanonicalRenderInput): readonly AnthropicMessage[
       } catch {
         // use raw text
       }
-      messages.push({
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: toolUseId,
-            content: resultContent,
-            ...(isError ? { is_error: true } : {}),
-          },
-        ],
-      });
+      const block: AnthropicContentBlock = {
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content: resultContent,
+        ...(isError ? { is_error: true } : {}),
+      };
+      const lastMsg = messages[messages.length - 1];
+      if (lastMsg && lastMsg.role === "user" && Array.isArray(lastMsg.content)) {
+        (lastMsg.content as AnthropicContentBlock[]).push(block);
+      } else {
+        messages.push({
+          role: "user",
+          content: [block],
+        });
+      }
       continue;
     }
 
@@ -266,17 +271,21 @@ function renderMessages(input: CanonicalRenderInput): readonly AnthropicMessage[
       try {
         const raw = JSON.parse(fragmentText(f)) as Record<string, unknown>;
         if (raw && typeof raw === "object" && raw.protocol === "terminus.tool-call.v1" && typeof raw.provider_call_id === "string") {
-          messages.push({
-            role: "assistant",
-            content: [
-              {
-                type: "tool_use",
-                id: raw.provider_call_id,
-                name: String(raw.tool_name),
-                input: (raw.arguments as Record<string, unknown>) ?? {},
-              },
-            ],
-          });
+          const block: AnthropicContentBlock = {
+            type: "tool_use",
+            id: raw.provider_call_id,
+            name: String(raw.tool_name),
+            input: (raw.arguments as Record<string, unknown>) ?? {},
+          };
+          const lastMsg = messages[messages.length - 1];
+          if (lastMsg && lastMsg.role === "assistant" && Array.isArray(lastMsg.content)) {
+            (lastMsg.content as AnthropicContentBlock[]).push(block);
+          } else {
+            messages.push({
+              role: "assistant",
+              content: [block],
+            });
+          }
           continue;
         }
       } catch {
@@ -369,3 +378,5 @@ export function renderRequest(input: CanonicalRenderInput): Promise<RenderedProv
 }
 
 export * from "./model_profiles.js";
+export * from "./stream.js";
+

--- a/packages/provider-anthropic/src/stream.ts
+++ b/packages/provider-anthropic/src/stream.ts
@@ -1,0 +1,255 @@
+/**
+ * @terminus/provider-anthropic — Stream decoding and normalization for Anthropic Messages API.
+ */
+import type { ModelKey, TokenCount } from "@terminus/domain";
+import type {
+  ProviderResponseChunk,
+  UsageRecord,
+} from "@terminus/provider-core";
+
+const MAX_EVENT_BYTES = 1024 * 1024;
+
+export interface SseEvent {
+  readonly event: string | null;
+  readonly data: string;
+}
+
+export async function* decodeSse(
+  chunks: AsyncIterable<string | Uint8Array>,
+  decoder: TextDecoder = new TextDecoder(),
+): AsyncIterable<SseEvent> {
+  let buffer = "";
+  for await (const chunk of chunks) {
+    buffer += typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+    if (buffer.length > MAX_EVENT_BYTES * 2) {
+      throw new Error("Anthropic SSE buffer exceeded maximum bound");
+    }
+    let boundary = nextBoundary(buffer);
+    while (boundary !== null) {
+      const raw = buffer.slice(0, boundary.index);
+      buffer = buffer.slice(boundary.index + boundary.length);
+      if (raw.length > MAX_EVENT_BYTES) {
+        throw new Error("Anthropic SSE event exceeded maximum bound");
+      }
+      const parsed = parseEvent(raw);
+      if (parsed !== null) yield parsed;
+      boundary = nextBoundary(buffer);
+    }
+  }
+  buffer += decoder.decode();
+  if (buffer.trim() !== "") {
+    if (buffer.length > MAX_EVENT_BYTES) {
+      throw new Error("Anthropic SSE event exceeded maximum bound");
+    }
+    const parsed = parseEvent(buffer);
+    if (parsed !== null) yield parsed;
+  }
+}
+
+function nextBoundary(buffer: string): { readonly index: number; readonly length: number } | null {
+  const lf = buffer.indexOf("\n\n");
+  const crlf = buffer.indexOf("\r\n\r\n");
+  if (lf === -1 && crlf === -1) return null;
+  if (crlf !== -1 && (lf === -1 || crlf < lf)) return { index: crlf, length: 4 };
+  return { index: lf, length: 2 };
+}
+
+function parseEvent(raw: string): SseEvent | null {
+  let event: string | null = null;
+  const data: string[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    if (line === "" || line.startsWith(":")) continue;
+    const separator = line.indexOf(":");
+    const field = separator === -1 ? line : line.slice(0, separator);
+    const value = separator === -1 ? "" : line.slice(separator + 1).replace(/^ /, "");
+    if (field === "event") event = value;
+    if (field === "data") data.push(value);
+  }
+  return data.length === 0 ? null : { event, data: data.join("\n") };
+}
+
+interface ToolAccumulator {
+  id: string;
+  name: string;
+  argumentsJson: string;
+}
+
+export async function* decodeAnthropicMessagesStream(
+  chunks: AsyncIterable<string | Uint8Array>,
+  model: ModelKey = "anthropic/claude-3-5-sonnet" as ModelKey,
+): AsyncIterable<ProviderResponseChunk> {
+  const events = decodeSse(chunks);
+  const tools = new Map<number, ToolAccumulator>();
+  let inputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+  let outputTokens = 0;
+  let reasoningTokens = 0;
+  let done = false;
+
+  for await (const event of events) {
+    const value = jsonRecord(event.data);
+    const type = typeof value.type === "string" ? value.type : event.event;
+
+    if (type === "error") {
+      yield errorChunk(value.error ?? value);
+      continue;
+    }
+
+    if (type === "message_start") {
+      const message = optionalRecord(value.message);
+      const usage = optionalRecord(message.usage);
+      inputTokens = numberOrZero(usage.input_tokens);
+      cacheReadTokens = numberOrZero(usage.cache_read_input_tokens);
+      cacheWriteTokens = numberOrZero(usage.cache_creation_input_tokens);
+      continue;
+    }
+
+    if (type === "content_block_start") {
+      const block = optionalRecord(value.content_block);
+      if (block.type === "tool_use") {
+        tools.set(integerOrZero(value.index), {
+          id: stringOrEmpty(block.id),
+          name: stringOrEmpty(block.name),
+          argumentsJson: Object.keys(optionalRecord(block.input)).length > 0 ? JSON.stringify(block.input) : "",
+        });
+      }
+      continue;
+    }
+
+    if (type === "content_block_delta") {
+      const delta = optionalRecord(value.delta);
+      if (delta.type === "text_delta" && typeof delta.text === "string") {
+        yield { kind: "text", text: delta.text };
+      } else if (delta.type === "thinking_delta" && typeof delta.thinking === "string") {
+        yield { kind: "text", reasoning: delta.thinking };
+      } else if (delta.type === "input_json_delta") {
+        const index = integerOrZero(value.index);
+        const current = tools.get(index) ?? { id: "", name: "", argumentsJson: "" };
+        current.argumentsJson += stringOrEmpty(delta.partial_json);
+        tools.set(index, current);
+      }
+      continue;
+    }
+
+    if (type === "content_block_stop") {
+      yield* flushTools(tools, integerOrZero(value.index));
+      continue;
+    }
+
+    if (type === "message_delta") {
+      const usage = optionalRecord(value.usage);
+      if (usage.output_tokens !== undefined) {
+        outputTokens = numberOrZero(usage.output_tokens);
+      }
+      continue;
+    }
+
+    if (type === "message_stop") {
+      yield* flushTools(tools);
+      yield {
+        kind: "done",
+        usage: anthropicUsage(inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, reasoningTokens),
+      };
+      done = true;
+    }
+  }
+
+  if (!done) {
+    yield { kind: "error", errorCode: "TRUNCATED_STREAM", errorMessage: "Anthropic Messages stream ended before message_stop" };
+  }
+}
+
+export function decodeAnthropicStream(
+  chunks: AsyncIterable<string | Uint8Array>,
+  model?: ModelKey,
+): AsyncIterable<ProviderResponseChunk> {
+  return decodeAnthropicMessagesStream(chunks, model);
+}
+
+function* flushTools(
+  tools: Map<number, ToolAccumulator>,
+  onlyIndex?: number,
+): Generator<ProviderResponseChunk> {
+  const indexes = onlyIndex === undefined ? [...tools.keys()].sort((a, b) => a - b) : [onlyIndex];
+  for (const index of indexes) {
+    const tool = tools.get(index);
+    if (tool === undefined) continue;
+    tools.delete(index);
+    if (tool.id === "" || tool.name === "") {
+      yield { kind: "error", errorCode: "INVALID_TOOL_CALL", errorMessage: "Anthropic tool call omitted id or name" };
+      continue;
+    }
+    let args: unknown;
+    try {
+      args = JSON.parse(tool.argumentsJson || "{}");
+    } catch {
+      yield { kind: "error", errorCode: "INVALID_TOOL_ARGUMENTS", errorMessage: `Anthropic tool ${tool.name} emitted invalid JSON arguments` };
+      continue;
+    }
+    if (!isRecord(args)) {
+      yield { kind: "error", errorCode: "INVALID_TOOL_ARGUMENTS", errorMessage: `Anthropic tool ${tool.name} arguments must be an object` };
+      continue;
+    }
+    yield { kind: "tool_call", toolCall: { toolCallId: tool.id, toolName: tool.name, arguments: args } };
+  }
+}
+
+function errorChunk(input: unknown): ProviderResponseChunk {
+  const value = optionalRecord(input);
+  return {
+    kind: "error",
+    errorCode: typeof value.type === "string" ? value.type : typeof value.code === "string" ? value.code : "PROVIDER_ERROR",
+    errorMessage: typeof value.message === "string" ? value.message : "Anthropic request failed",
+  };
+}
+
+export function anthropicUsage(
+  inputTokens: number,
+  outputTokens: number,
+  cacheReadTokens: number = 0,
+  cacheWriteTokens: number = 0,
+  reasoningTokens: number = 0,
+): UsageRecord {
+  return {
+    inputTokens: BigInt(inputTokens) as TokenCount,
+    cachedInputTokens: BigInt(cacheReadTokens) as TokenCount,
+    cacheWriteTokens: BigInt(cacheWriteTokens) as TokenCount,
+    outputTokens: BigInt(outputTokens) as TokenCount,
+    reasoningTokens: BigInt(reasoningTokens) as TokenCount,
+    toolSchemaTokens: 0n as TokenCount,
+    latencyMs: 0,
+    timeToFirstTokenMs: null,
+  };
+}
+
+function jsonRecord(json: string): Readonly<Record<string, unknown>> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("Anthropic emitted invalid JSON in an SSE event");
+  }
+  if (!isRecord(parsed)) throw new Error("Anthropic SSE event data must be a JSON object");
+  return parsed;
+}
+
+function optionalRecord(value: unknown): Readonly<Record<string, unknown>> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function integerOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function stringOrEmpty(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}

--- a/packages/provider-openai/src/index.ts
+++ b/packages/provider-openai/src/index.ts
@@ -68,6 +68,43 @@ export interface OpenAiRequestBody {
   readonly metadata?: Readonly<Record<string, string>> | undefined;
 }
 
+// ────────────────────────── OpenAI Responses API wire shapes ─────────────────
+
+export interface OpenAiResponsesTool {
+  readonly type: "function";
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: Readonly<Record<string, unknown>>;
+  readonly strict?: boolean | undefined;
+}
+
+export interface OpenAiResponsesReasoningConfig {
+  readonly effort?: "minimal" | "low" | "medium" | "high" | undefined;
+  readonly summary?: "auto" | "none" | undefined;
+}
+
+export interface OpenAiResponsesInputItem {
+  readonly role?: "system" | "developer" | "user" | "assistant" | undefined;
+  readonly content?: string | undefined;
+  readonly type?: "message" | "function_call" | "function_call_output" | undefined;
+  readonly call_id?: string | undefined;
+  readonly output?: string | undefined;
+}
+
+export interface OpenAiResponsesRequestBody {
+  readonly model: string;
+  readonly input: string | readonly OpenAiResponsesInputItem[];
+  readonly tools?: readonly OpenAiResponsesTool[] | undefined;
+  readonly tool_choice?: "auto" | "none" | "required" | { readonly type: "function"; readonly name: string } | undefined;
+  readonly temperature?: number | undefined;
+  readonly max_output_tokens?: number | undefined;
+  readonly reasoning?: OpenAiResponsesReasoningConfig | undefined;
+  readonly store?: boolean | undefined;
+  readonly previous_response_id?: string | undefined;
+  readonly stream: true;
+  readonly metadata?: Readonly<Record<string, string>> | undefined;
+}
+
 // ────────────────────────── Renderer ─────────────────────────────────────────
 
 export class OpenAiRenderer extends BaseProviderRenderer {
@@ -355,12 +392,47 @@ export interface OpenAiTransport extends ProviderTransport {
   ): AsyncIterable<ProviderResponseChunk>;
 }
 
-/** Convenience entrypoint for tests/adapters: render a request body. */
+/** Convenience entrypoint for tests/adapters: render a chat-completions request body. */
 export function renderRequest(input: CanonicalRenderInput): Promise<RenderedProviderRequest> {
   const renderer = new OpenAiRenderer();
   return renderer.render(input);
 }
 
+/** Render a native OpenAI Responses API request body. */
+export async function renderResponsesRequest(input: CanonicalRenderInput): Promise<RenderedProviderRequest> {
+  const renderer = new OpenAiRenderer();
+  const rendered = await renderer.render(input);
+  const body = rendered.body as unknown as OpenAiRequestBody;
+  const responsesBody: OpenAiResponsesRequestBody = {
+    model: body.model,
+    input: body.messages as unknown as readonly OpenAiResponsesInputItem[],
+    stream: true,
+    ...(body.tools && body.tools.length > 0
+      ? {
+          tools: body.tools.map((t) => ({
+            type: "function" as const,
+            name: t.function.name,
+            description: t.function.description,
+            parameters: t.function.parameters,
+            strict: t.function.strict,
+          })),
+        }
+      : {}),
+    ...(body.max_output_tokens !== undefined ? { max_output_tokens: body.max_output_tokens } : {}),
+    ...(body.reasoning_effort !== undefined
+      ? { reasoning: { effort: body.reasoning_effort, summary: "auto" } }
+      : {}),
+    ...(body.previous_response_id !== undefined ? { previous_response_id: body.previous_response_id } : {}),
+    ...(body.store !== undefined ? { store: body.store } : {}),
+  };
+  return {
+    ...rendered,
+    body: responsesBody as unknown as Readonly<Record<string, unknown>>,
+  };
+}
+
 export type { ProviderRenderer, ProviderResponseChunk };
 
 export * from "./model_profiles.js";
+export * from "./stream.js";
+

--- a/packages/provider-openai/src/openai_responses.test.ts
+++ b/packages/provider-openai/src/openai_responses.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelKey, TokenCount, ContentHash, Uuid7 } from "@terminus/domain";
+import { micros } from "@terminus/domain";
+import type {
+  CanonicalRenderInput,
+  ContextFragment,
+  ModelCapabilitySnapshot,
+  ProviderCapabilitySnapshot,
+  ProviderToolSchema,
+} from "@terminus/provider-core";
+import {
+  OpenAiRenderer,
+  renderResponsesRequest,
+  decodeOpenAiResponsesStream,
+  decodeOpenAiChatStream,
+} from "./index.js";
+
+const DEFAULT_PROVIDER_CAPS: ProviderCapabilitySnapshot = {
+  providerId: "openai",
+  observedAt: "2026-08-24T00:00:00Z",
+  source: "test",
+  context: {
+    advertisedTokens: 128_000,
+    testedSafeTokens: 100_000,
+    roleSupport: ["system", "user", "assistant", "tool", "developer"],
+    imageInput: true,
+    toolCalling: true,
+    parallelToolCalls: true,
+    structuredOutput: true,
+  },
+  continuation: {
+    nativeId: true,
+    crossRequest: true,
+    compaction: false,
+    compatibilityKey: "openai-responses-v1",
+  },
+  caching: {
+    mode: "automatic_prefix",
+    exactPrefixRequired: true,
+    minimumTokens: 1024,
+    ttlOptions: ["5m", "1h"],
+    toolOrderSensitive: false,
+    usageReporting: true,
+  },
+  reasoning: {
+    supported: true,
+    budgetControl: true,
+    summaryAvailable: true,
+  },
+  economics: {
+    inputMicrosPerMillion: micros(2_500_000),
+    cachedInputMicrosPerMillion: micros(1_250_000),
+    outputMicrosPerMillion: micros(10_000_000),
+    reasoningAccounting: true,
+  },
+  reliability: {
+    toolCallSuccess: 0.96,
+    structuredOutputSuccess: 0.97,
+    editCohortSuccess: 0.88,
+    latencyPercentiles: { p50: 800, p95: 3000, p99: 6000 },
+  },
+  policy: {
+    allowedConfidentiality: ["public", "workspace", "secret_adjacent"],
+    retentionMode: "organization_zdr",
+    region: "us-east-1",
+  },
+};
+
+const DEFAULT_MODEL_KEY = "openai/gpt-4o" as ModelKey;
+
+const DEFAULT_MODEL_CAPS: ModelCapabilitySnapshot = {
+  modelKey: DEFAULT_MODEL_KEY,
+  providerId: "openai",
+  snapshot: DEFAULT_PROVIDER_CAPS,
+  observedAt: "2026-08-24T00:00:00Z",
+};
+
+const DUMMY_TOOL: ProviderToolSchema = {
+  id: "search",
+  version: "1.0.0",
+  summary: "Search workspace",
+  inputSchema: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+  resultSchema: { type: "object", properties: { results: { type: "array" } } },
+  sideEffectClass: "READ_ONLY",
+  requiredCapabilities: [],
+  trustLevel: "builtin",
+  maximumModelResultBytes: 4096,
+  maximumArtifactBytes: 1048576,
+  defaultTimeoutMs: 5000,
+  policyTags: [],
+};
+
+function mkFragment(id: string, kind: string, text: string): ContextFragment {
+  return {
+    id,
+    kind: kind as ContextFragment["kind"],
+    textContent: text,
+    contentRef: { uri: `artifact://${id}` as any, hash: `sha256:${id}` as ContentHash, mediaType: "text/plain", bytes: 100n as any },
+    source: { uri: `test://${id}`, producer: "test", producerVersion: "1.0", observedAt: "2026-08-24T00:00:00Z" as any, observedBy: "control", evidenceRefs: [] },
+    sourceVersion: null,
+    authority: 100,
+    priority: 1,
+    trust: "trusted",
+    confidentiality: "workspace",
+    injectionRisk: "none",
+    exactness: "exact",
+    scope: { workspaceId: null, sessionId: null, taskId: null, pathPatterns: [] },
+    freshness: { observedAt: "2026-08-24T00:00:00Z" as any, sourceVersion: null, stale: false, staleReason: null },
+    dependencies: [],
+    invalidation: [],
+    estimatedTokens: { [DEFAULT_MODEL_KEY]: 25 } as any,
+    selectionFeatures: { relevance: 1, novelty: 1, coverage: 1, uncertaintyReduction: 1, riskReduction: 1, modelCompatibility: 1, redundancyPenalty: 0, injectionPenalty: 0 },
+  };
+}
+
+describe("OpenAI Responses Connector", () => {
+  test("renders valid OpenAI Responses API request body", async () => {
+    const input: CanonicalRenderInput = {
+      provider: DEFAULT_PROVIDER_CAPS,
+      model: DEFAULT_MODEL_CAPS,
+      manifestId: "01934567-89ab-7000-8000-cdef01234567" as Uuid7,
+      fragments: [
+        mkFragment("f1", "authority", "System instructions."),
+        mkFragment("f2", "user_attachment", "Search for main.rs"),
+      ],
+      toolSchemas: [DUMMY_TOOL],
+      cachePlan: { stablePrefixHash: `sha256:${"0".repeat(64)}` as ContentHash, breakpoints: [] },
+      continuationId: "resp_12345",
+      outputProfile: "terse",
+      reasoningReserveTokens: 500n as TokenCount,
+      outputReserveTokens: 4096n as TokenCount,
+      hardInputLimit: 100000n as TokenCount,
+      signal: null,
+    };
+
+    const rendered = await renderResponsesRequest(input);
+    const body = rendered.body as Record<string, unknown>;
+
+    expect(body.model).toBe("openai/gpt-4o");
+    expect(body.stream).toBe(true);
+    expect(body.previous_response_id).toBe("resp_12345");
+    expect(body.max_output_tokens).toBe(4096);
+    expect(body.store).toBe(false);
+
+    const reasoning = body.reasoning as { effort: string; summary: string };
+    expect(reasoning).toBeDefined();
+    expect(reasoning.effort).toBe("medium");
+
+    const tools = body.tools as Array<{ type: string; name: string; strict?: boolean }>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0]!.type).toBe("function");
+    expect(tools[0]!.name).toBe("search");
+    expect(tools[0]!.strict).toBe(true);
+
+    const inputItems = body.input as Array<{ role: string; content: string }>;
+    expect(inputItems).toHaveLength(2);
+    expect(inputItems[0]!.role).toBe("developer");
+    expect(inputItems[0]!.content).toBe("System instructions.");
+    expect(inputItems[1]!.role).toBe("user");
+    expect(inputItems[1]!.content).toBe("Search for main.rs");
+  });
+
+  test("streams and decodes Responses API SSE frames", async () => {
+    async function* sseGenerator(): AsyncIterable<string> {
+      yield "event: response.output_text.delta\ndata: {\"delta\":\"Hello \"}\n\n";
+      yield "event: response.reasoning_text.delta\ndata: {\"delta\":\"Thinking...\"}\n\n";
+      yield "event: response.output_text.delta\ndata: {\"delta\":\"world!\"}\n\n";
+      yield "event: response.output_item.added\ndata: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"search\",\"arguments\":\"\"}}\n\n";
+      yield "event: response.function_call_arguments.delta\ndata: {\"output_index\":0,\"delta\":\"{\\\"query\\\":\\\"term\\\"}\"}\n\n";
+      yield "event: response.output_item.done\ndata: {\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"search\",\"arguments\":\"{\\\"query\\\":\\\"term\\\"}\"}}\n\n";
+      yield "event: response.completed\ndata: {\"response\":{\"id\":\"resp_999\",\"usage\":{\"input_tokens\":100,\"output_tokens\":20,\"input_tokens_details\":{\"cached_tokens\":40},\"output_tokens_details\":{\"reasoning_tokens\":15}}}}\n\n";
+    }
+
+    const chunks: any[] = [];
+    for await (const chunk of decodeOpenAiResponsesStream(sseGenerator())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(5);
+    expect(chunks[0]).toEqual({ kind: "text", text: "Hello " });
+    expect(chunks[1]).toEqual({ kind: "text", reasoning: "Thinking..." });
+    expect(chunks[2]).toEqual({ kind: "text", text: "world!" });
+    expect(chunks[3]).toEqual({
+      kind: "tool_call",
+      toolCall: {
+        toolCallId: "call_1",
+        toolName: "search",
+        arguments: { query: "term" },
+      },
+    });
+    expect(chunks[4]).toEqual({
+      kind: "done",
+      continuationId: "resp_999",
+      usage: {
+        inputTokens: 100n as TokenCount,
+        cachedInputTokens: 40n as TokenCount,
+        cacheWriteTokens: 0n as TokenCount,
+        outputTokens: 20n as TokenCount,
+        reasoningTokens: 15n as TokenCount,
+        toolSchemaTokens: 0n as TokenCount,
+        latencyMs: 0,
+        timeToFirstTokenMs: null,
+      },
+    });
+  });
+
+  test("streams and decodes Chat Completions SSE frames", async () => {
+    async function* chatSseGenerator(): AsyncIterable<string> {
+      yield "data: {\"choices\":[{\"delta\":{\"content\":\"Hi!\"}}]}\n\n";
+      yield "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"reasoning...\"}}]}\n\n";
+      yield "data: {\"usage\":{\"prompt_tokens\":50,\"completion_tokens\":10,\"prompt_tokens_details\":{\"cached_tokens\":20}}}\n\n";
+      yield "data: [DONE]\n\n";
+    }
+
+    const chunks: any[] = [];
+    for await (const chunk of decodeOpenAiChatStream(chatSseGenerator())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toEqual({ kind: "text", text: "Hi!" });
+    expect(chunks[1]).toEqual({ kind: "text", reasoning: "reasoning..." });
+    expect(chunks[2]).toEqual({
+      kind: "done",
+      usage: {
+        inputTokens: 50n as TokenCount,
+        cachedInputTokens: 20n as TokenCount,
+        cacheWriteTokens: 0n as TokenCount,
+        outputTokens: 10n as TokenCount,
+        reasoningTokens: 0n as TokenCount,
+        toolSchemaTokens: 0n as TokenCount,
+        latencyMs: 0,
+        timeToFirstTokenMs: null,
+      },
+    });
+  });
+});

--- a/packages/provider-openai/src/stream.ts
+++ b/packages/provider-openai/src/stream.ts
@@ -1,0 +1,308 @@
+/**
+ * @terminus/provider-openai — Stream decoding and normalization for OpenAI Responses and Chat Completions APIs.
+ */
+import type { ModelKey, TokenCount } from "@terminus/domain";
+import type {
+  ProviderResponseChunk,
+  UsageRecord,
+} from "@terminus/provider-core";
+
+const MAX_EVENT_BYTES = 1024 * 1024;
+
+export interface SseEvent {
+  readonly event: string | null;
+  readonly data: string;
+}
+
+export async function* decodeSse(
+  chunks: AsyncIterable<string | Uint8Array>,
+  decoder: TextDecoder = new TextDecoder(),
+): AsyncIterable<SseEvent> {
+  let buffer = "";
+  for await (const chunk of chunks) {
+    buffer += typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+    if (buffer.length > MAX_EVENT_BYTES * 2) {
+      throw new Error("OpenAI SSE buffer exceeded maximum bound");
+    }
+    let boundary = nextBoundary(buffer);
+    while (boundary !== null) {
+      const raw = buffer.slice(0, boundary.index);
+      buffer = buffer.slice(boundary.index + boundary.length);
+      if (raw.length > MAX_EVENT_BYTES) {
+        throw new Error("OpenAI SSE event exceeded maximum bound");
+      }
+      const parsed = parseEvent(raw);
+      if (parsed !== null) yield parsed;
+      boundary = nextBoundary(buffer);
+    }
+  }
+  buffer += decoder.decode();
+  if (buffer.trim() !== "") {
+    if (buffer.length > MAX_EVENT_BYTES) {
+      throw new Error("OpenAI SSE event exceeded maximum bound");
+    }
+    const parsed = parseEvent(buffer);
+    if (parsed !== null) yield parsed;
+  }
+}
+
+function nextBoundary(buffer: string): { readonly index: number; readonly length: number } | null {
+  const lf = buffer.indexOf("\n\n");
+  const crlf = buffer.indexOf("\r\n\r\n");
+  if (lf === -1 && crlf === -1) return null;
+  if (crlf !== -1 && (lf === -1 || crlf < lf)) return { index: crlf, length: 4 };
+  return { index: lf, length: 2 };
+}
+
+function parseEvent(raw: string): SseEvent | null {
+  let event: string | null = null;
+  const data: string[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    if (line === "" || line.startsWith(":")) continue;
+    const separator = line.indexOf(":");
+    const field = separator === -1 ? line : line.slice(0, separator);
+    const value = separator === -1 ? "" : line.slice(separator + 1).replace(/^ /, "");
+    if (field === "event") event = value;
+    if (field === "data") data.push(value);
+  }
+  return data.length === 0 ? null : { event, data: data.join("\n") };
+}
+
+interface ToolAccumulator {
+  id: string;
+  name: string;
+  argumentsJson: string;
+}
+
+export async function* decodeOpenAiResponsesStream(
+  chunks: AsyncIterable<string | Uint8Array>,
+  model: ModelKey = "openai/gpt-4o" as ModelKey,
+): AsyncIterable<ProviderResponseChunk> {
+  const events = decodeSse(chunks);
+  const tools = new Map<number, ToolAccumulator>();
+  let done = false;
+  for await (const event of events) {
+    const value = jsonRecord(event.data);
+    const type = typeof value.type === "string" ? value.type : event.event;
+    if (type === "error" || type === "response.failed") {
+      yield errorChunk(value.error ?? value);
+      continue;
+    }
+    if (type === "response.output_text.delta" && typeof value.delta === "string") {
+      yield { kind: "text", text: value.delta };
+      continue;
+    }
+    if ((type === "response.reasoning_text.delta" || type === "response.reasoning.delta") && typeof value.delta === "string") {
+      yield { kind: "text", reasoning: value.delta };
+      continue;
+    }
+    if (type === "response.output_item.added") {
+      const item = optionalRecord(value.item);
+      if (item.type === "function_call") {
+        const index = integerOrZero(value.output_index);
+        tools.set(index, {
+          id: stringOrEmpty(item.call_id) || stringOrEmpty(item.id),
+          name: stringOrEmpty(item.name),
+          argumentsJson: stringOrEmpty(item.arguments),
+        });
+      }
+      continue;
+    }
+    if (type === "response.function_call_arguments.delta") {
+      const index = integerOrZero(value.output_index);
+      const current = tools.get(index) ?? { id: stringOrEmpty(value.item_id), name: "", argumentsJson: "" };
+      current.argumentsJson += stringOrEmpty(value.delta);
+      tools.set(index, current);
+      continue;
+    }
+    if (type === "response.output_item.done") {
+      const item = optionalRecord(value.item);
+      if (item.type === "function_call") {
+        const index = integerOrZero(value.output_index);
+        const current = tools.get(index) ?? { id: "", name: "", argumentsJson: "" };
+        tools.set(index, {
+          id: stringOrEmpty(item.call_id) || stringOrEmpty(item.id) || current.id,
+          name: stringOrEmpty(item.name) || current.name,
+          argumentsJson: stringOrEmpty(item.arguments) || current.argumentsJson,
+        });
+        yield* flushTools(tools, index);
+      }
+      continue;
+    }
+    if (type === "response.completed") {
+      yield* flushTools(tools);
+      const response = optionalRecord(value.response);
+      const usage = optionalRecord(response.usage);
+      yield {
+        kind: "done",
+        ...(typeof response.id === "string" ? { continuationId: response.id } : {}),
+        ...(Object.keys(usage).length > 0 ? { usage: responsesUsage(usage) } : {}),
+      };
+      done = true;
+    }
+  }
+  if (!done) {
+    yield { kind: "error", errorCode: "TRUNCATED_STREAM", errorMessage: "Responses stream ended before response.completed" };
+  }
+}
+
+export async function* decodeOpenAiChatStream(
+  chunks: AsyncIterable<string | Uint8Array>,
+  model: ModelKey = "openai/gpt-4o" as ModelKey,
+): AsyncIterable<ProviderResponseChunk> {
+  const events = decodeSse(chunks);
+  const tools = new Map<number, ToolAccumulator>();
+  let finalUsage: UsageRecord | undefined;
+  let done = false;
+  for await (const event of events) {
+    if (event.data === "[DONE]") {
+      yield* flushTools(tools);
+      yield { kind: "done", ...(finalUsage ? { usage: finalUsage } : {}) };
+      done = true;
+      continue;
+    }
+    const value = jsonRecord(event.data);
+    if (value.error !== undefined) {
+      yield errorChunk(value.error);
+      continue;
+    }
+    const usage = optionalRecord(value.usage);
+    if (Object.keys(usage).length > 0) finalUsage = chatUsage(usage);
+    if (!Array.isArray(value.choices)) continue;
+    for (const rawChoice of value.choices) {
+      const choice = optionalRecord(rawChoice);
+      const delta = optionalRecord(choice.delta);
+      if (typeof delta.content === "string" && delta.content !== "") {
+        yield { kind: "text", text: delta.content };
+      }
+      if (typeof delta.reasoning_content === "string" && delta.reasoning_content !== "") {
+        yield { kind: "text", reasoning: delta.reasoning_content };
+      }
+      if (Array.isArray(delta.tool_calls)) {
+        for (const rawTool of delta.tool_calls) {
+          const tool = optionalRecord(rawTool);
+          const index = typeof tool.index === "number" && Number.isInteger(tool.index) ? tool.index : 0;
+          const fn = optionalRecord(tool.function);
+          const current = tools.get(index) ?? { id: "", name: "", argumentsJson: "" };
+          tools.set(index, {
+            id: typeof tool.id === "string" ? tool.id : current.id,
+            name: typeof fn.name === "string" ? fn.name : current.name,
+            argumentsJson: current.argumentsJson + (typeof fn.arguments === "string" ? fn.arguments : ""),
+          });
+        }
+      }
+      if (choice.finish_reason === "tool_calls") yield* flushTools(tools);
+    }
+  }
+  if (!done) {
+    yield { kind: "error", errorCode: "TRUNCATED_STREAM", errorMessage: "Chat completions stream ended before [DONE]" };
+  }
+}
+
+export function decodeOpenAiStream(
+  chunks: AsyncIterable<string | Uint8Array>,
+  protocol: "responses" | "chat_completions" = "responses",
+  model?: ModelKey,
+): AsyncIterable<ProviderResponseChunk> {
+  return protocol === "responses"
+    ? decodeOpenAiResponsesStream(chunks, model)
+    : decodeOpenAiChatStream(chunks, model);
+}
+
+function* flushTools(
+  tools: Map<number, ToolAccumulator>,
+  onlyIndex?: number,
+): Generator<ProviderResponseChunk> {
+  const indexes = onlyIndex === undefined ? [...tools.keys()].sort((a, b) => a - b) : [onlyIndex];
+  for (const index of indexes) {
+    const tool = tools.get(index);
+    if (tool === undefined) continue;
+    tools.delete(index);
+    if (tool.id === "" || tool.name === "") {
+      yield { kind: "error", errorCode: "INVALID_TOOL_CALL", errorMessage: "OpenAI tool call omitted id or name" };
+      continue;
+    }
+    let args: unknown;
+    try {
+      args = JSON.parse(tool.argumentsJson || "{}");
+    } catch {
+      yield { kind: "error", errorCode: "INVALID_TOOL_ARGUMENTS", errorMessage: `OpenAI tool ${tool.name} emitted invalid JSON arguments` };
+      continue;
+    }
+    if (!isRecord(args)) {
+      yield { kind: "error", errorCode: "INVALID_TOOL_ARGUMENTS", errorMessage: `OpenAI tool ${tool.name} arguments must be an object` };
+      continue;
+    }
+    yield { kind: "tool_call", toolCall: { toolCallId: tool.id, toolName: tool.name, arguments: args } };
+  }
+}
+
+function errorChunk(input: unknown): ProviderResponseChunk {
+  const value = optionalRecord(input);
+  return {
+    kind: "error",
+    errorCode: typeof value.code === "string" ? value.code : typeof value.type === "string" ? value.type : "PROVIDER_ERROR",
+    errorMessage: typeof value.message === "string" ? value.message : "OpenAI request failed",
+  };
+}
+
+export function responsesUsage(value: Readonly<Record<string, unknown>>): UsageRecord {
+  const details = optionalRecord(value.input_tokens_details);
+  const outputDetails = optionalRecord(value.output_tokens_details);
+  return {
+    inputTokens: BigInt(numberOrZero(value.input_tokens)) as TokenCount,
+    cachedInputTokens: BigInt(numberOrZero(details.cached_tokens)) as TokenCount,
+    cacheWriteTokens: 0n as TokenCount,
+    outputTokens: BigInt(numberOrZero(value.output_tokens)) as TokenCount,
+    reasoningTokens: BigInt(numberOrZero(outputDetails.reasoning_tokens)) as TokenCount,
+    toolSchemaTokens: 0n as TokenCount,
+    latencyMs: 0,
+    timeToFirstTokenMs: null,
+  };
+}
+
+export function chatUsage(value: Readonly<Record<string, unknown>>): UsageRecord {
+  const details = optionalRecord(value.prompt_tokens_details);
+  const completionDetails = optionalRecord(value.completion_tokens_details);
+  return {
+    inputTokens: BigInt(numberOrZero(value.prompt_tokens)) as TokenCount,
+    cachedInputTokens: BigInt(numberOrZero(details.cached_tokens)) as TokenCount,
+    cacheWriteTokens: 0n as TokenCount,
+    outputTokens: BigInt(numberOrZero(value.completion_tokens)) as TokenCount,
+    reasoningTokens: BigInt(numberOrZero(completionDetails.reasoning_tokens)) as TokenCount,
+    toolSchemaTokens: 0n as TokenCount,
+    latencyMs: 0,
+    timeToFirstTokenMs: null,
+  };
+}
+
+function jsonRecord(json: string): Readonly<Record<string, unknown>> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("OpenAI emitted invalid JSON in an SSE event");
+  }
+  if (!isRecord(parsed)) throw new Error("OpenAI SSE event data must be a JSON object");
+  return parsed;
+}
+
+function optionalRecord(value: unknown): Readonly<Record<string, unknown>> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function integerOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function stringOrEmpty(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}

--- a/packages/terminus-kernel-client/src/generated-ts-proto/google/protobuf/timestamp.ts
+++ b/packages/terminus-kernel-client/src/generated-ts-proto/google/protobuf/timestamp.ts
@@ -102,16 +102,15 @@ export const protobufPackage = "google.protobuf";
  */
 export interface Timestamp {
   /**
-   * Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
-   * be between -315576000000 and 315576000000 inclusive (which corresponds to
-   * 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
+   * Represents seconds of UTC time since Unix epoch
+   * 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+   * 9999-12-31T23:59:59Z inclusive.
    */
   seconds: number;
   /**
-   * Non-negative fractions of a second at nanosecond resolution. This field is
-   * the nanosecond portion of the duration, not an alternative to seconds.
-   * Negative second values with fractions must still have non-negative nanos
-   * values that count forward in time. Must be between 0 and 999,999,999
+   * Non-negative fractions of a second at nanosecond resolution. Negative
+   * second values with fractions must still have non-negative nanos values
+   * that count forward in time. Must be from 0 to 999,999,999
    * inclusive.
    */
   nanos: number;

--- a/packages/terminus-kernel-client/src/generated-ts-proto/google/protobuf/timestamp.ts
+++ b/packages/terminus-kernel-client/src/generated-ts-proto/google/protobuf/timestamp.ts
@@ -102,15 +102,16 @@ export const protobufPackage = "google.protobuf";
  */
 export interface Timestamp {
   /**
-   * Represents seconds of UTC time since Unix epoch
-   * 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-   * 9999-12-31T23:59:59Z inclusive.
+   * Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
+   * be between -315576000000 and 315576000000 inclusive (which corresponds to
+   * 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
    */
   seconds: number;
   /**
-   * Non-negative fractions of a second at nanosecond resolution. Negative
-   * second values with fractions must still have non-negative nanos values
-   * that count forward in time. Must be from 0 to 999,999,999
+   * Non-negative fractions of a second at nanosecond resolution. This field is
+   * the nanosecond portion of the duration, not an alternative to seconds.
+   * Negative second values with fractions must still have non-negative nanos
+   * values that count forward in time. Must be between 0 and 999,999,999
    * inclusive.
    */
   nanos: number;


### PR DESCRIPTION
## Summary

Closes #21
Closes #22

### Overview
This PR implements native connector support for:
1. **OpenAI Responses API (`/v1/responses`)** (Issue #21):
   - Wire types (`OpenAiResponsesRequestBody`, `OpenAiResponsesTool`, `OpenAiResponsesInputItem`, `OpenAiResponsesReasoningConfig`).
   - `renderResponsesRequest()` helper producing canonical `/v1/responses` payloads with reasoning effort, function call output items, strict tool parameters, continuation token (`previous_response_id`), and ZDR store policy flags.
   - SSE stream decoder (`decodeOpenAiResponsesStream`, `decodeOpenAiChatStream`, `decodeOpenAiStream`) normalizing `response.output_text.delta`, `response.reasoning_text.delta`, and `response.function_call_arguments.delta` into `ProviderResponseChunk`s.
   - Usage accounting extraction for input tokens, cached prompt tokens, output tokens, and reasoning tokens.
   - Registered connector broker descriptor in the Rust kernel service.

2. **Anthropic Messages API (`/v1/messages`)** (Issue #22):
   - Wire support for `cache_control: { type: 'ephemeral' }` on tool definitions and system blocks.
   - Multi-turn tool execution formatting linking `tool_use` and `tool_result` blocks.
   - SSE stream decoder (`decodeAnthropicMessagesStream`, `decodeAnthropicStream`) normalizing `message_start`, `content_block_start` (thinking/tool_use), `content_block_delta` (thinking_delta/input_json_delta), `content_block_stop`, and `message_stop`.
   - Token accounting with `cache_read_input_tokens` and `cache_creation_input_tokens`.
   - Registered `anthropic-messages` (`NamedHeader("x-api-key")`) connector broker in the Rust kernel service.

### Verification
- Unit & Conformance test suites passed in `packages/provider-openai`, `packages/provider-anthropic`, `packages/provider-core`, `packages/provider-zen`, and `packages/provider-conformance`.
- Rust kernel and connector tests passed in `crates/terminus-kernel`.
- Ran full verification: `just check`, `just codegen-check`, `just unit`, `just check-all`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements native connectors for OpenAI Responses and Anthropic Messages with streaming decode and usage accounting. Previously only generic/chat paths existed; now responses/messages are first-class, enabling reasoning text, linked tool calls, continuation IDs, and cache token reporting.

- Adds request renderers and SSE decoders: `renderResponsesRequest`, `decodeOpenAiResponsesStream`/`decodeOpenAiChatStream` (plus `decodeOpenAiStream`), and `decodeAnthropicMessagesStream` (plus `decodeAnthropicStream`), normalizing text, reasoning, tool calls, and done/usage events.
- Supports OpenAI reasoning effort and continuation (`previous_response_id`) and strict tool parameters; supports Anthropic `cache_control: { type: "ephemeral" }` with multi-turn `tool_use`/`tool_result` linkage.
- Extracts usage details including cached input, cache creation, output, and reasoning tokens; returns OpenAI `response.id` as `continuationId`.
- Registers connectors in the Rust kernel broker: `openai-responses` (Bearer), `openai-chat` (Bearer), and `anthropic-messages` (`x-api-key` header).
- Satisfies #21 (OpenAI Responses) and #22 (Anthropic Messages) with wire types, renderers, decoders, and kernel registration; test suites added in `packages/provider-openai` and `packages/provider-anthropic` and decoders exported via each package `index.ts`.

**Rollout**
- Configure API credentials for `openai-responses`, `openai-chat`, and `anthropic-messages` in the connector broker (Anthropic uses `x-api-key`).
- No migration required; existing chat-completions flows remain. To adopt the new paths, select the corresponding connector and use the new stream decoders.

<sup>Written for commit 6f96c7950b14f036928751e4782d9adaf9d20f05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ezzy1630/Terminus/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

