### PR TITLE
feat(retrieval): retrieval-v1 cohort, BM25 consolidation, and retrieval telemetry

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,7 +7,9 @@ test_patterns = [
   "**/tests/**/*.py",
   "**/*_test.rs",
   "**/tests/**/*.rs",
-  "**/tests/**"
+  "**/tests/**",
+  "**/hidden/**",
+  "**/hidden/**/*.py"
 ]
 
 exclude_patterns = [

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,10 @@ Enforced structurally:
 
 `docs/security/non-bypassability-tests.md` defines the required bypass suite. The dedicated `tests/security/bypass/` fixtures are not all present, so the repository MUST NOT treat the full non-bypassability claim as proven. Any release making that claim must implement and pass every required fixture.
 
+> [!NOTE]
+> **Kernel enforcement vs. whole-system non-bypassability**:
+> The Rust kernel enforces capability tokens, operation classes, and broker isolation at its interface boundary. However, whole-system non-bypassability across all client processes, platform sandboxes, and host side channels remains an unproved release claim until the full adversarial bypass suite and signed platform conformance evidence are completed.
+
 ## Threat model (SPEC §36.2, Appendix I.1)
 
 Terminus assumes the following may be malicious or compromised:

--- a/crates/terminus-kernel-protocol/src/generated/terminus/kernel/v1/terminus.kernel.v1.rs
+++ b/crates/terminus-kernel-protocol/src/generated/terminus/kernel/v1/terminus.kernel.v1.rs
@@ -1241,6 +1241,9 @@ pub mod connector_chunk {
 // Code intelligence service (SPEC §11.8, §31.1)
 // =============================================================================
 
+/// CodeSearchRequest performs code intelligence search.
+/// Currently delegates to inspect_symbol and performs exact symbol lookup
+/// against the heuristic symbol index.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CodeSearchRequest {
     #[prost(message, optional, tag="1")]

--- a/crates/terminus-kernel/src/services.rs
+++ b/crates/terminus-kernel/src/services.rs
@@ -4103,6 +4103,8 @@ impl CodeIntelligenceService {
         Ok(service)
     }
 
+    /// Inspect a symbol. Performs exact symbol name lookup against the heuristic
+    /// symbol index (SPEC §34.6).
     pub fn inspect(
         &self,
         ctx: &RequestContext,

--- a/docs/generated/INDEX.md
+++ b/docs/generated/INDEX.md
@@ -21,7 +21,7 @@
 
 | File | Size |
 |---|---:|
-| `component-maturity.md` | 12301 B |
+| `component-maturity.md` | 12299 B |
 | `config.md` | 6602 B |
 | `events.md` | 18610 B |
 | `inventory.md` | 1299 B |

--- a/docs/generated/component-maturity.md
+++ b/docs/generated/component-maturity.md
@@ -31,7 +31,7 @@ Tiers: `fixture` → `stub` → `experimental` → `preview` → `production`. `
 | `mini-service-kernel` | mini-service | `mini-services/terminus-kernel` | `experimental` | Rust kernel gRPC-over-private-UDS boundary; file resolution still uses one configured data root, so arbitrary registered-root isolation is unverified |
 | `forge-evals` | python-package | `python/forge_evals` | `experimental` | Runners plus sealed Phase 11/12 structural contracts; canary pairing, held-out partition enforcement, cohort metrics, and trajectory diffs now unit-tested at HEAD; no real held-out promotion, trusted signature verifier, or dominance evidence |
 | `terminus-authz` | rust-crate | `crates/terminus-authz` | `experimental` | Signed/scoped capability tokens real; revocation + nonce state in-memory (audit 4.4) |
-| `terminus-code-intel` | rust-crate | `crates/terminus-code-intel` | `experimental` | Tree-sitter symbol index with basic tests |
+| `terminus-code-intel` | rust-crate | `crates/terminus-code-intel` | `experimental` | heuristic symbol index with basic tests |
 | `terminus-connector` | rust-crate | `crates/terminus-connector` | `experimental` | L7 connector broker: grant-bound credential injection, exact-operation binding, rustls HTTPS with pinned resolved addresses, bounded response capture, and response scrubbing; real-account inference conformance is not recorded at HEAD |
 | `terminus-egress` | rust-crate | `crates/terminus-egress` | `experimental` | L4 broker real (DNS/IP/port/scheme/bytes); no L7 intent semantics yet (audit 4.7) |
 | `terminus-git` | rust-crate | `crates/terminus-git` | `experimental` | Protected worktree/commit/merge operations, small test set |

--- a/docs/generated/inventory.md
+++ b/docs/generated/inventory.md
@@ -16,9 +16,9 @@ A declared test is not a passing run. Executed-test evidence lives in CI
 | External harness adapters | 1 | directories in adapters/ |
 | Mini-services | 2 | directories in mini-services/ |
 | Declared Rust tests | 606 | `#[test]` + `#[tokio::test]` occurrences in crates/** (excl. generated) |
-| TypeScript test files | 177 | `*.test.{ts,tsx}` in packages/ + apps/ |
-| Declared TypeScript test blocks | 1687 | `test(/it(` occurrences in those files |
-| Declared Python tests | 530 | `def test_*` in python/** |
+| TypeScript test files | 178 | `*.test.{ts,tsx}` in packages/ + apps/ |
+| Declared TypeScript test blocks | 1694 | `test(/it(` occurrences in those files |
+| Declared Python tests | 543 | `def test_*` in python/** |
 | ADRs | 56 | docs/decisions/ADR-*.md |
 | Runbooks | 15 | docs/runbooks/*.md |
 | SQLite migrations | 30 | migrations/sqlite/*.sql |

--- a/docs/generated/inventory.md
+++ b/docs/generated/inventory.md
@@ -18,7 +18,7 @@ A declared test is not a passing run. Executed-test evidence lives in CI
 | Declared Rust tests | 606 | `#[test]` + `#[tokio::test]` occurrences in crates/** (excl. generated) |
 | TypeScript test files | 177 | `*.test.{ts,tsx}` in packages/ + apps/ |
 | Declared TypeScript test blocks | 1687 | `test(/it(` occurrences in those files |
-| Declared Python tests | 529 | `def test_*` in python/** |
+| Declared Python tests | 530 | `def test_*` in python/** |
 | ADRs | 56 | docs/decisions/ADR-*.md |
 | Runbooks | 15 | docs/runbooks/*.md |
 | SQLite migrations | 30 | migrations/sqlite/*.sql |

--- a/docs/generated/inventory.md
+++ b/docs/generated/inventory.md
@@ -18,7 +18,7 @@ A declared test is not a passing run. Executed-test evidence lives in CI
 | Declared Rust tests | 606 | `#[test]` + `#[tokio::test]` occurrences in crates/** (excl. generated) |
 | TypeScript test files | 178 | `*.test.{ts,tsx}` in packages/ + apps/ |
 | Declared TypeScript test blocks | 1694 | `test(/it(` occurrences in those files |
-| Declared Python tests | 543 | `def test_*` in python/** |
+| Declared Python tests | 545 | `def test_*` in python/** |
 | ADRs | 56 | docs/decisions/ADR-*.md |
 | Runbooks | 15 | docs/runbooks/*.md |
 | SQLite migrations | 30 | migrations/sqlite/*.sql |

--- a/evals/registry.yaml
+++ b/evals/registry.yaml
@@ -123,6 +123,7 @@ campaigns:
 # owns the evidence and promotion requirements.
 cohorts:
   - {id: canary, class: reliability, private_holdout_required: false}
+  - {id: retrieval-v1, class: retrieval, private_holdout_required: false}
   - {id: tiny_bugfix, class: coding, private_holdout_required: true}
   - {id: cross_file_feature, class: coding, private_holdout_required: true}
   - {id: refactor, class: coding, private_holdout_required: true}

--- a/evals/registry.yaml
+++ b/evals/registry.yaml
@@ -63,6 +63,14 @@ tiers:
     release_evidence: true
 
 suites:
+  - id: retrieval-v1
+    manifest: evals/suites/retrieval-v1.yaml
+    task_roots:
+      - python/forge_evals/evals/tasks/retrieval-v1
+    source: internal
+    license: proprietary
+    default_tier: tier1
+    live_provider_required_for_promotion: true
   - id: terminus-internal
     manifest: evals/suites/forge-internal.yaml
     task_roots:

--- a/evals/suites/forge-internal.yaml
+++ b/evals/suites/forge-internal.yaml
@@ -8,7 +8,7 @@ suite:
     evals/tasks/.
   source: internal
   license: proprietary
-  task_count: 12
+  task_count: 4
   default_timeout_seconds: 600
   default_budget:
     model_micros: 1500000

--- a/evals/suites/retrieval-v1.yaml
+++ b/evals/suites/retrieval-v1.yaml
@@ -1,0 +1,30 @@
+suite:
+  id: retrieval-v1
+  version: 1
+  description: |
+    Terminus retrieval-v1 evaluation cohort. Five representative tasks measuring
+    retrieval efficacy across 3 archetypes:
+    - 2 named file tasks (retrieval-named-01, retrieval-named-02)
+    - 2 symptom/behavior tasks (retrieval-symptom-01, retrieval-symptom-02)
+    - 1 cross-file reference task (retrieval-cross-file-01)
+  source: internal
+  license: proprietary
+  task_count: 5
+  default_timeout_seconds: 600
+  default_budget:
+    model_micros: 1500000
+    compute_seconds: 300
+    wall_clock_seconds: 600
+    human_approvals: 0
+  grader_version: 1.0.0
+  metrics:
+    primary: resolved
+    secondary: [scope_retained, cost_usd, turns_taken, retrieval_latency_ms, hit_rate]
+  cohorts:
+    - retrieval-v1
+  tasks:
+    - retrieval-named-01
+    - retrieval-named-02
+    - retrieval-symptom-01
+    - retrieval-symptom-02
+    - retrieval-cross-file-01

--- a/maturity.yaml
+++ b/maturity.yaml
@@ -64,7 +64,7 @@ components:
   - { id: terminus-egress, kind: rust-crate, path: crates/terminus-egress, tier: experimental,
       basis: "L4 broker real (DNS/IP/port/scheme/bytes); no L7 intent semantics yet (audit 4.7)" }
   - { id: terminus-code-intel, kind: rust-crate, path: crates/terminus-code-intel, tier: experimental,
-      basis: "Tree-sitter symbol index with basic tests" }
+      basis: "heuristic symbol index with basic tests" }
   - { id: terminus-extension-runtime, kind: rust-crate, path: crates/terminus-extension-runtime, tier: stub,
       basis: "WASI execution is unavailable without Wasmtime; invocation fails closed with an unavailable error" }
   - { id: terminus-git, kind: rust-crate, path: crates/terminus-git, tier: experimental,

--- a/mini-services/terminus-control/src/agent/retrieval-pipeline.test.ts
+++ b/mini-services/terminus-control/src/agent/retrieval-pipeline.test.ts
@@ -38,13 +38,13 @@ describe("Retrieval Pipeline & Chunked Lexical Candidate", () => {
   describe("Lexical Chunk Index Cache & Invalidation", () => {
     it("caches index by workspace and revision, invalidating when revision changes", async () => {
       let readCount = 0;
-      const fakeReader = async ({ path }: { path: string }) => {
+      const fakeReader = ({ path }: { path: string }) => {
         readCount++;
-        return {
+        return Promise.resolve({
           content: `export function helper_${path}() { return 42; }`,
           fileSha256: "sha256:file1",
           totalLines: 1,
-        };
+        });
       };
 
       const index1 = await getOrBuildLexicalChunkIndex(
@@ -124,23 +124,23 @@ describe("Retrieval Pipeline & Chunked Lexical Candidate", () => {
 
     const mockClients: KernelUdsClients = {
       codeIntel: {
-        Search: async (req) => {
+        Search: (req) => {
           if (req.query === "calculateShipping") {
-            return {
+            return Promise.resolve({
               results: [{ path: "src/shipping.py", line: 10, symbol: "calculateShipping", method: "exact_path_symbol" }],
               truncated: false,
-            };
+            });
           }
-          return { results: [], truncated: false };
+          return Promise.resolve({ results: [], truncated: false });
         },
       },
       files: {
-        Read: async (req) => {
-          const content = `def calculateShipping(weight):\n    if weight > 50:\n        return 0\n    return 10\n`;
-          return {
+        Read: () => {
+          const content = "def calculateShipping(weight):\n    if weight > 50:\n        return 0\n    return 10\n";
+          return Promise.resolve({
             modelProjectionUtf8: new TextEncoder().encode(content),
             sourceVersion: { sha256: "sha256:shipping123" },
-          };
+          });
         },
       },
     };
@@ -148,7 +148,7 @@ describe("Retrieval Pipeline & Chunked Lexical Candidate", () => {
     it("minimal profile runs exact symbol and repository map without lexical candidate", async () => {
       const pipeline = kernelRetrievalPipeline({
         clients: mockClients,
-        buildContext: async () => fakeContext,
+        buildContext: () => Promise.resolve(fakeContext),
         observedAt: "2026-09-02T20:00:00Z" as any,
         modelKey: "test-model" as any,
         sessionId: "sess-1",
@@ -181,7 +181,7 @@ describe("Retrieval Pipeline & Chunked Lexical Candidate", () => {
     it("adaptive profile activates chunked lexical BM25 candidate for natural language queries", async () => {
       const pipeline = kernelRetrievalPipeline({
         clients: mockClients,
-        buildContext: async () => fakeContext,
+        buildContext: () => Promise.resolve(fakeContext),
         observedAt: "2026-09-02T20:00:00Z" as any,
         modelKey: "test-model" as any,
         sessionId: "sess-1",

--- a/mini-services/terminus-control/src/agent/retrieval-pipeline.test.ts
+++ b/mini-services/terminus-control/src/agent/retrieval-pipeline.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import {
+  chunkSourceLines,
+  clearLexicalIndexCache,
+  getOrBuildLexicalChunkIndex,
+  kernelRetrievalPipeline,
+  RetrievalTelemetryCollector,
+  type KernelUdsClients,
+} from "./retrieval-pipeline.js";
+import type { RequestContext } from "../../../../packages/terminus-kernel-client/src/generated-ts-proto/terminus/kernel/v1/kernel.js";
+
+describe("Retrieval Pipeline & Chunked Lexical Candidate", () => {
+  beforeEach(() => {
+    clearLexicalIndexCache();
+  });
+
+  describe("chunkSourceLines", () => {
+    it("splits content into bounded, overlap-aware chunks with line numbers", () => {
+      const lines = Array.from({ length: 120 }, (_, i) => `line ${i + 1}: function test_${i}() {}`).join("\n");
+      const chunks = chunkSourceLines("src/test.ts", lines, "sha256:abc12345", 50, 10);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+      expect(chunks[0]!.startLine).toBe(1);
+      expect(chunks[0]!.endLine).toBe(50);
+      expect(chunks[0]!.sourceSha256).toBe("sha256:abc12345");
+
+      // Chunk 1 starts with step = 50 - 10 = 40 (0-indexed line 40 -> 1-indexed line 41)
+      expect(chunks[1]!.startLine).toBe(41);
+      expect(chunks[1]!.endLine).toBe(90);
+    });
+
+    it("returns empty array for blank content", () => {
+      const chunks = chunkSourceLines("src/empty.ts", "   \n\n  ", null);
+      expect(chunks).toHaveLength(0);
+    });
+  });
+
+  describe("Lexical Chunk Index Cache & Invalidation", () => {
+    it("caches index by workspace and revision, invalidating when revision changes", async () => {
+      let readCount = 0;
+      const fakeReader = async ({ path }: { path: string }) => {
+        readCount++;
+        return {
+          content: `export function helper_${path}() { return 42; }`,
+          fileSha256: "sha256:file1",
+          totalLines: 1,
+        };
+      };
+
+      const index1 = await getOrBuildLexicalChunkIndex(
+        "ws-1",
+        "rev-1",
+        ["src/a.ts", "src/b.ts"],
+        fakeReader,
+      );
+      expect(readCount).toBe(2);
+      expect(index1.revision).toBe("rev-1");
+
+      // Second call with same workspace + revision should hit cache without new reads
+      const index2 = await getOrBuildLexicalChunkIndex(
+        "ws-1",
+        "rev-1",
+        ["src/a.ts", "src/b.ts"],
+        fakeReader,
+      );
+      expect(readCount).toBe(2);
+      expect(index2).toBe(index1);
+
+      // Third call with new revision invalidates and performs fresh reads
+      const index3 = await getOrBuildLexicalChunkIndex(
+        "ws-1",
+        "rev-2",
+        ["src/a.ts", "src/b.ts"],
+        fakeReader,
+      );
+      expect(readCount).toBe(4);
+      expect(index3.revision).toBe("rev-2");
+    });
+  });
+
+  describe("Telemetry Collection", () => {
+    it("records queries, exact-symbol misses, hydration, latency, and verified files", () => {
+      const collector = new RetrievalTelemetryCollector();
+      collector.recordQuery({
+        text: "calculateShippingThreshold",
+        reason: "task objective",
+        suggestedMethods: ["exact_path_symbol"],
+      });
+      collector.recordMethod("exact_path_symbol");
+      collector.recordHits(0, false); // Miss
+      collector.recordHydration("src/shipping.py", 1200, 300);
+      collector.recordLatency(45.5);
+      collector.recordChangedOrVerifiedFiles(["src/shipping.py"]);
+
+      const snap = collector.snapshot();
+      expect(snap.queries).toHaveLength(1);
+      expect(snap.exactSymbolMisses).toBe(1);
+      expect(snap.hitCount).toBe(0);
+      expect(snap.filesHydrated).toContain("src/shipping.py");
+      expect(snap.bytesRead).toBe(1200);
+      expect(snap.tokensRead).toBe(300);
+      expect(snap.retrievalLatencyMs).toBe(46);
+      expect(snap.retrievedFilesChangedOrVerified).toContain("src/shipping.py");
+    });
+  });
+
+  describe("kernelRetrievalPipeline behavior & profile gating", () => {
+    const fakeContext: RequestContext = {
+      requestId: "req-1",
+      sessionId: "sess-1",
+      taskId: "task-1",
+      workspaceId: "ws-1",
+      initiator: "user",
+      principalId: "user-1",
+      capabilities: [],
+      issuedAt: "2026-09-02T20:00:00Z" as any,
+      deadlineAt: "2026-09-02T20:30:00Z" as any,
+      policyProfileId: "default",
+      traceParent: "",
+      environmentClass: "local_dev",
+      auditTrailId: "audit-1",
+      idempotencyKey: "idem-1",
+    };
+
+    const mockClients: KernelUdsClients = {
+      codeIntel: {
+        Search: async (req) => {
+          if (req.query === "calculateShipping") {
+            return {
+              results: [{ path: "src/shipping.py", line: 10, symbol: "calculateShipping", method: "exact_path_symbol" }],
+              truncated: false,
+            };
+          }
+          return { results: [], truncated: false };
+        },
+      },
+      files: {
+        Read: async (req) => {
+          const content = `def calculateShipping(weight):\n    if weight > 50:\n        return 0\n    return 10\n`;
+          return {
+            modelProjectionUtf8: new TextEncoder().encode(content),
+            sourceVersion: { sha256: "sha256:shipping123" },
+          };
+        },
+      },
+    };
+
+    it("minimal profile runs exact symbol and repository map without lexical candidate", async () => {
+      const pipeline = kernelRetrievalPipeline({
+        clients: mockClients,
+        buildContext: async () => fakeContext,
+        observedAt: "2026-09-02T20:00:00Z" as any,
+        modelKey: "test-model" as any,
+        sessionId: "sess-1",
+        taskId: "task-1",
+        workspaceId: "ws-1",
+        repositoryMap: {
+          indexRevision: "rev-1",
+          entries: [{ path: "src/shipping.py", symbols: ["calculateShipping"] }],
+          totalEntries: 1,
+          continuationToken: null,
+        },
+        profileMode: "minimal",
+      });
+
+      // Query with natural language that doesn't match an exact symbol
+      const results = await pipeline.retrieve([
+        { text: "fix free shipping threshold calculation", reason: "symptom", suggestedMethods: ["lexical_bm25"] },
+      ]);
+
+      // In minimal profile, only repo map is present (method is exact_path_symbol, NOT semantic)
+      expect(results).toHaveLength(1);
+      expect(results[0]!.fragment.id).toContain("kernel-repository-map");
+      expect(results[0]!.method).toBe("exact_path_symbol"); // Not labeled as semantic!
+
+      const snap = pipeline.telemetry.snapshot();
+      expect(snap.exactSymbolMisses).toBe(1);
+      expect(snap.searchMethodsUsed).not.toContain("lexical_bm25");
+    });
+
+    it("adaptive profile activates chunked lexical BM25 candidate for natural language queries", async () => {
+      const pipeline = kernelRetrievalPipeline({
+        clients: mockClients,
+        buildContext: async () => fakeContext,
+        observedAt: "2026-09-02T20:00:00Z" as any,
+        modelKey: "test-model" as any,
+        sessionId: "sess-1",
+        taskId: "task-1",
+        workspaceId: "ws-1",
+        repositoryMap: {
+          indexRevision: "rev-1",
+          entries: [{ path: "src/shipping.py", symbols: ["calculateShipping"] }],
+          totalEntries: 1,
+          continuationToken: null,
+        },
+        allowedScope: { readPaths: ["src/shipping.py"], writePaths: ["src/shipping.py"] },
+        profileMode: "adaptive",
+      });
+
+      const results = await pipeline.retrieve([
+        { text: "calculate shipping threshold weight", reason: "symptom", suggestedMethods: ["lexical_bm25"] },
+      ]);
+
+      // Should retrieve repository map + lexical chunk match!
+      expect(results.length).toBeGreaterThan(1);
+      const lexicalResult = results.find((r) => r.method === "lexical_bm25");
+      expect(lexicalResult).toBeDefined();
+      expect(lexicalResult!.fragment.textContent).toContain("calculateShipping");
+
+      const snap = pipeline.telemetry.snapshot();
+      expect(snap.searchMethodsUsed).toContain("lexical_bm25");
+    });
+  });
+});

--- a/mini-services/terminus-control/src/agent/retrieval-pipeline.ts
+++ b/mini-services/terminus-control/src/agent/retrieval-pipeline.ts
@@ -1,0 +1,680 @@
+/**
+ * Production Retrieval Pipeline & Chunked Lexical Candidate.
+ *
+ * Implements SPEC §8, §33, §34.6:
+ * - Extracted from terminus-control index.ts
+ * - Exact-symbol lookup via kernel CodeIntelligenceRpc
+ * - Chunked lexical BM25 candidate (overlap-aware, token-normalized, kernel-read)
+ * - Cache keyed by workspace and repository-map revision
+ * - Fail-soft error handling
+ * - Comprehensive per-turn telemetry collection
+ * - Strict profile gating: lexical retrieval active only in adaptive profile
+ */
+
+import { randomUUID, createHash } from "node:crypto";
+import type {
+  ContextFragment,
+  ModelKey,
+  Rfc3339Timestamp,
+} from "@terminus/domain";
+import type { RequestContext } from "../../../../packages/terminus-kernel-client/src/generated-ts-proto/terminus/kernel/v1/kernel.js";
+import type { KernelUdsClients } from "../kernel-uds.js";
+import { computeContentHash } from "@terminus/context-ir";
+import {
+  scoreDocumentBm25,
+  tokenizeForBm25,
+  computeDocumentFrequencies,
+  computeAvgDocTokens,
+} from "@terminus/context-ir";
+import type {
+  CompileInput,
+  EvidenceGap,
+  RetrievalMethod,
+  RetrievalPipeline,
+  RetrievalQuery,
+  RetrievalResult,
+} from "@terminus/context-compiler";
+import {
+  buildRepositoryMapFragment,
+  hydrateSearchHit,
+  type SearchHit,
+  type WorkspaceFileReader,
+} from "./retrieval-hydrator.js";
+import { selectTaskScopedRepositoryMap } from "./repository-signals.js";
+
+export interface RepositoryMapObservation {
+  readonly indexRevision: string;
+  readonly entries: readonly { readonly path: string; readonly symbols: readonly string[] }[];
+  readonly totalEntries: number;
+  readonly continuationToken: string | null;
+}
+
+export interface RetrievalTelemetry {
+  readonly queries: readonly {
+    readonly text: string;
+    readonly reason: string;
+    readonly suggestedMethods: readonly string[];
+  }[];
+  readonly searchMethodsUsed: readonly string[];
+  readonly hitCount: number;
+  readonly exactSymbolMisses: number;
+  readonly filesHydrated: readonly string[];
+  readonly bytesRead: number;
+  readonly tokensRead: number;
+  readonly fragmentsAdmitted: readonly string[];
+  readonly retrievalLatencyMs: number;
+  readonly truncationOrContinuationFailures: number;
+  readonly retrievedFiles: readonly string[];
+  readonly retrievedFilesChangedOrVerified: readonly string[];
+}
+
+export class RetrievalTelemetryCollector {
+  private readonly queriesList: { text: string; reason: string; suggestedMethods: readonly string[] }[] = [];
+  private readonly methodsUsed = new Set<string>();
+  private totalHits = 0;
+  private symbolMisses = 0;
+  private readonly hydratedFiles = new Set<string>();
+  private totalBytesRead = 0;
+  private totalTokensRead = 0;
+  private admittedFragments = new Set<string>();
+  private latencyMs = 0;
+  private failures = 0;
+  private readonly retrievedFilesSet = new Set<string>();
+  private changedOrVerified = new Set<string>();
+
+  recordQuery(query: RetrievalQuery): void {
+    this.queriesList.push({
+      text: query.text,
+      reason: query.reason,
+      suggestedMethods: [...query.suggestedMethods],
+    });
+  }
+
+  recordMethod(method: string): void {
+    this.methodsUsed.add(method);
+  }
+
+  recordHits(count: number, exactMatch: boolean): void {
+    this.totalHits += count;
+    if (count === 0 || !exactMatch) {
+      this.symbolMisses++;
+    }
+  }
+
+  recordHydration(path: string, bytes: number, tokens: number): void {
+    this.hydratedFiles.add(path);
+    this.retrievedFilesSet.add(path);
+    this.totalBytesRead += bytes;
+    this.totalTokensRead += tokens;
+  }
+
+  recordAdmittedFragment(fragmentId: string): void {
+    this.admittedFragments.add(fragmentId);
+  }
+
+  recordAdmittedFragments(fragmentIds: readonly string[]): void {
+    for (const id of fragmentIds) {
+      this.admittedFragments.add(id);
+    }
+  }
+
+  recordLatency(ms: number): void {
+    this.latencyMs += ms;
+  }
+
+  recordFailure(): void {
+    this.failures++;
+  }
+
+  recordChangedOrVerifiedFiles(paths: readonly string[]): void {
+    for (const p of paths) {
+      if (this.retrievedFilesSet.has(p)) {
+        this.changedOrVerified.add(p);
+      }
+    }
+  }
+
+  snapshot(): RetrievalTelemetry {
+    return {
+      queries: [...this.queriesList],
+      searchMethodsUsed: [...this.methodsUsed],
+      hitCount: this.totalHits,
+      exactSymbolMisses: this.symbolMisses,
+      filesHydrated: [...this.hydratedFiles],
+      bytesRead: this.totalBytesRead,
+      tokensRead: this.totalTokensRead,
+      fragmentsAdmitted: [...this.admittedFragments],
+      retrievalLatencyMs: Math.round(this.latencyMs),
+      truncationOrContinuationFailures: this.failures,
+      retrievedFiles: [...this.retrievedFilesSet],
+      retrievedFilesChangedOrVerified: [...this.changedOrVerified],
+    };
+  }
+}
+
+export interface SourceChunk {
+  readonly path: string;
+  readonly startLine: number;
+  readonly endLine: number;
+  readonly content: string;
+  readonly tokens: readonly string[];
+  readonly sourceSha256: string | null;
+}
+
+export interface LexicalChunkIndex {
+  readonly workspaceId: string;
+  readonly revision: string;
+  readonly chunks: readonly SourceChunk[];
+  readonly docFrequencies: ReadonlyMap<string, number>;
+  readonly avgDocTokens: number;
+}
+
+// Global cache for workspace lexical chunk indices: key = `${workspaceId}:${revision}`
+const LEXICAL_INDEX_CACHE = new Map<string, LexicalChunkIndex>();
+
+export function clearLexicalIndexCache(): void {
+  LEXICAL_INDEX_CACHE.clear();
+}
+
+/**
+ * Split source code into bounded, overlap-aware chunks.
+ */
+export function chunkSourceLines(
+  path: string,
+  content: string,
+  sourceSha256: string | null,
+  chunkLines = 60,
+  overlapLines = 15,
+): readonly SourceChunk[] {
+  const lines = content.split("\n");
+  if (lines.length === 0 || content.trim().length === 0) return [];
+
+  const chunks: SourceChunk[] = [];
+  const step = Math.max(1, chunkLines - overlapLines);
+
+  for (let start = 0; start < lines.length; start += step) {
+    const end = Math.min(lines.length, start + chunkLines);
+    const slice = lines.slice(start, end).join("\n");
+    const tokens = tokenizeForBm25(slice);
+    if (tokens.length > 0) {
+      chunks.push({
+        path,
+        startLine: start + 1,
+        endLine: end,
+        content: slice,
+        tokens,
+        sourceSha256,
+      });
+    }
+    if (end >= lines.length) break;
+  }
+
+  return chunks;
+}
+
+/**
+ * Build or retrieve cached lexical chunk index for a workspace revision.
+ * Reads files through the kernel WorkspaceFileReader exclusively.
+ */
+export async function getOrBuildLexicalChunkIndex(
+  workspaceId: string,
+  revision: string,
+  candidatePaths: readonly string[],
+  fileReader: WorkspaceFileReader,
+  maxFilesToIndex = 30,
+): Promise<LexicalChunkIndex> {
+  const cacheKey = `${workspaceId}:${revision}`;
+  const existing = LEXICAL_INDEX_CACHE.get(cacheKey);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const chunks: SourceChunk[] = [];
+  const pathsToIndex = candidatePaths.slice(0, maxFilesToIndex);
+
+  for (const path of pathsToIndex) {
+    try {
+      const readResult = await fileReader({
+        path,
+        startLine: 1,
+        endLine: 400, // index first 400 lines of top candidate files
+      });
+      if (readResult.content !== null && readResult.content.length > 0) {
+        const fileChunks = chunkSourceLines(path, readResult.content, readResult.fileSha256);
+        chunks.push(...fileChunks);
+      }
+    } catch {
+      // Fail-soft: skip unreadable files
+    }
+  }
+
+  const tokenizedDocs = chunks.map((c) => c.tokens);
+  const docFrequencies = computeDocumentFrequencies(tokenizedDocs);
+  const avgDocTokens = computeAvgDocTokens(tokenizedDocs);
+
+  const index: LexicalChunkIndex = {
+    workspaceId,
+    revision,
+    chunks,
+    docFrequencies,
+    avgDocTokens,
+  };
+
+  LEXICAL_INDEX_CACHE.set(cacheKey, index);
+  return index;
+}
+
+export interface KernelRetrievalPipelineOptions {
+  readonly clients: KernelUdsClients;
+  readonly buildContext: () => Promise<RequestContext>;
+  readonly observedAt: Rfc3339Timestamp;
+  readonly modelKey: ModelKey;
+  readonly sessionId: string;
+  readonly taskId: string;
+  readonly workspaceId: string;
+  readonly repositoryMap: RepositoryMapObservation | null;
+  readonly allowedScope?: { readonly readPaths: readonly string[]; readonly writePaths: readonly string[] };
+  readonly profileMode?: "minimal" | "adaptive";
+  readonly telemetry?: RetrievalTelemetryCollector;
+}
+
+export function mapRetrievalMethod(method: string): RetrievalMethod {
+  switch (method) {
+    case "tree_sitter":
+    case "lsp":
+    case "graph":
+      return method === "graph" ? "dependency_graph" : method;
+    case "lexical_bm25":
+      return method;
+    case "exact_path_symbol":
+      return method;
+    default:
+      return "lexical_bm25";
+  }
+}
+
+/**
+ * Creates the kernel retrieval pipeline with per-turn telemetry and optional
+ * chunked lexical retrieval candidate in adaptive profile mode.
+ */
+export function kernelRetrievalPipeline(
+  options: KernelRetrievalPipelineOptions,
+): RetrievalPipeline & { readonly telemetry: RetrievalTelemetryCollector } {
+  const {
+    clients,
+    buildContext,
+    observedAt,
+    modelKey,
+    sessionId,
+    taskId,
+    workspaceId,
+    repositoryMap,
+    allowedScope = { readPaths: [], writePaths: [] },
+    profileMode = "minimal",
+  } = options;
+
+  const telemetry = options.telemetry ?? new RetrievalTelemetryCollector();
+
+  const fileReader: WorkspaceFileReader = async ({ path, startLine, endLine }) => {
+    try {
+      const baseContext = await buildContext();
+      const read = await clients.files.Read({
+        context: {
+          ...baseContext,
+          requestId: randomUUID(),
+          idempotencyKey: `code-hydrate:${randomUUID()}`,
+        },
+        intent: {
+          userIntentRef: "retrieval-hydration",
+          taskContractHash: "",
+          trustLabel: "derived",
+          confidentialityLabel: "workspace",
+          taintSources: [],
+          policyProfileId: "secure-local-default",
+          expectedEffectClass: "read_local",
+        },
+        path: { workspaceId, relativePath: path },
+        mode: "ranges",
+        ranges: [{ startLine, endLine }],
+        symbols: [],
+        maxBytes: 48 * 1_024,
+        expectedSha256: "",
+      });
+      const decoded = new TextDecoder("utf-8", { fatal: false }).decode(read.modelProjectionUtf8);
+      const byteCount = read.modelProjectionUtf8.byteLength;
+      const tokenCount = Math.max(1, Math.ceil(decoded.length / 4));
+      telemetry.recordHydration(path, byteCount, tokenCount);
+      return {
+        content: decoded,
+        fileSha256: read.sourceVersion?.sha256 ?? null,
+        totalLines: null,
+      };
+    } catch {
+      return { content: null, fileSha256: null, totalLines: null };
+    }
+  };
+
+  // Build repository map fragment with exact_path_symbol label (stops labeling as semantic)
+  const repositoryMapFragment = repositoryMap === null || repositoryMap.entries.length === 0
+    ? null
+    : (() => {
+        const selection = selectTaskScopedRepositoryMap(
+          repositoryMap.entries
+            .slice(0, 200 * 8)
+            .map((entry) => ({ path: entry.path, symbols: entry.symbols })),
+          { readPaths: allowedScope.readPaths, writePaths: allowedScope.writePaths },
+        );
+        const entries = selection.entries;
+        const rendered = buildRepositoryMapFragment(entries, {
+          maxEntries: entries.length,
+          omittedEntries: Math.max(0, repositoryMap.entries.length - entries.length),
+          continuationToken: repositoryMap.continuationToken,
+          title: "Kernel repository map",
+        });
+        const hash = computeContentHash(rendered.text);
+        const bytes = new TextEncoder().encode(rendered.text).byteLength;
+        const pathPatterns = entries.map((entry) => entry.path);
+        const fragment: ContextFragment = {
+          id: `kernel-repository-map:${hash}`,
+          kind: "code",
+          contentRef: {
+            hash,
+            uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
+            mediaType: "text/plain",
+            bytes: BigInt(bytes) as ContextFragment["contentRef"]["bytes"],
+          },
+          textContent: rendered.text,
+          source: {
+            uri: `workspace://${workspaceId}/repository-map`,
+            producer: "terminus-kernel-code-intel",
+            producerVersion: "v1",
+            observedAt,
+            observedBy: "kernel",
+            evidenceRefs: [],
+          },
+          sourceVersion: repositoryMap.indexRevision,
+          authority: 55,
+          priority: 60,
+          trust: "derived",
+          confidentiality: "workspace",
+          injectionRisk: "low",
+          exactness: "semantics_preserving",
+          scope: {
+            workspaceId: workspaceId as ContextFragment["scope"]["workspaceId"],
+            sessionId: sessionId as ContextFragment["scope"]["sessionId"],
+            taskId: taskId as ContextFragment["scope"]["taskId"],
+            pathPatterns,
+          },
+          freshness: {
+            observedAt,
+            sourceVersion: repositoryMap.indexRevision,
+            stale: false,
+            staleReason: null,
+          },
+          dependencies: [],
+          invalidation: [{ kind: "file_changed", selector: `workspace://${workspaceId}` }],
+          estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(rendered.text.length / 4)) },
+          selectionFeatures: {
+            relevance: 0.65,
+            novelty: 0.9,
+            coverage: 0.95,
+            uncertaintyReduction: 0.85,
+            riskReduction: 0.55,
+            modelCompatibility: 1,
+            redundancyPenalty: 0,
+            injectionPenalty: 0,
+          },
+        };
+        return fragment;
+      })();
+
+  const retrieve = async (queries: readonly RetrievalQuery[]): Promise<readonly RetrievalResult[]> => {
+    const startTime = performance.now();
+    // Repository map fragment is labeled as exact_path_symbol (stopped labeling as semantic)
+    const results: RetrievalResult[] = repositoryMapFragment === null
+      ? []
+      : [{
+          fragment: repositoryMapFragment,
+          method: "exact_path_symbol",
+          rawScore: 0.8,
+          rerankedScore: 0.8,
+          sourceVersion: repositoryMapFragment.sourceVersion,
+          reason: "kernel repository map",
+        }];
+
+    const seen = new Set<string>();
+
+    for (const query of queries) {
+      telemetry.recordQuery(query);
+
+      // 1. Exact-symbol lookup via kernel CodeIntelligenceRpc
+      try {
+        const baseContext = await buildContext();
+        telemetry.recordMethod("exact_path_symbol");
+        const response = await clients.codeIntel.Search({
+          context: {
+            ...baseContext,
+            requestId: randomUUID(),
+            idempotencyKey: `code-search:${randomUUID()}`,
+          },
+          workspaceId,
+          query: query.text,
+          limit: 5,
+        });
+
+        if (response.truncated) {
+          telemetry.recordFailure();
+          throw new Error(
+            `code-intelligence retrieval truncated for query ${JSON.stringify(query.text)}${response.continuation === undefined ? " without a continuation token" : "; continuation RPC is unavailable"}`,
+          );
+        }
+
+        const hits = response.results;
+        telemetry.recordHits(hits.length, hits.length > 0);
+
+        for (const hit of hits) {
+          const id = `kernel-code:${hit.path}:${hit.line}:${hit.symbol}`;
+          if (seen.has(id)) continue;
+          seen.add(id);
+
+          const searchHit: SearchHit = {
+            path: hit.path,
+            line: hit.line,
+            symbol: typeof hit.symbol === "string" && hit.symbol.length > 0 ? hit.symbol : null,
+            method: hit.method,
+          };
+          const hydratedSpan = await hydrateSearchHit(searchHit, fileReader);
+          const text = hydratedSpan?.fragmentText ?? [
+            `# Code intelligence result`,
+            `path: ${hit.path}`,
+            `line: ${hit.line}`,
+            `symbol: ${hit.symbol}`,
+            `index method: ${hit.method}`,
+            `(source span unavailable — request read for implementation)`,
+          ].join("\n");
+          const hash = computeContentHash(text);
+          const fragment: ContextFragment = {
+            id,
+            kind: "code",
+            contentRef: {
+              hash,
+              uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
+              mediaType: "text/plain",
+              bytes: BigInt(new TextEncoder().encode(text).byteLength) as ContextFragment["contentRef"]["bytes"],
+            },
+            textContent: text,
+            source: {
+              uri: `workspace://${hit.path}`,
+              producer: "terminus-kernel-code-intel",
+              producerVersion: "v1",
+              observedAt,
+              observedBy: "kernel",
+              evidenceRefs: [],
+            },
+            sourceVersion: null,
+            authority: 55,
+            priority: 55,
+            trust: "derived",
+            confidentiality: "workspace",
+            injectionRisk: "low",
+            exactness: "recoverable_by_reference",
+            scope: {
+              workspaceId: null,
+              sessionId: sessionId as ContextFragment["scope"]["sessionId"],
+              taskId: taskId as ContextFragment["scope"]["taskId"],
+              pathPatterns: [hit.path],
+            },
+            freshness: { observedAt, sourceVersion: null, stale: false, staleReason: null },
+            dependencies: [],
+            invalidation: [{ kind: "file_changed", selector: hit.path }],
+            estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(text.length / 4)) },
+            selectionFeatures: {
+              relevance: query.suggestedMethods.includes(mapRetrievalMethod(hit.method)) ? 0.9 : 0.6,
+              novelty: 0.7,
+              coverage: 0.8,
+              uncertaintyReduction: 0.7,
+              riskReduction: 0.5,
+              modelCompatibility: 1,
+              redundancyPenalty: 0,
+              injectionPenalty: 0,
+            },
+          };
+          results.push({
+            fragment,
+            method: mapRetrievalMethod(hit.method),
+            rawScore: 1,
+            rerankedScore: 1,
+            sourceVersion: hydratedSpan?.fileSha256 ?? null,
+            reason: query.reason,
+          });
+        }
+      } catch (error) {
+        telemetry.recordFailure();
+        if (profileMode === "minimal") {
+          throw error;
+        }
+      }
+
+      // 2. Candidate: Chunked lexical BM25 retrieval (ACTIVE ONLY IN ADAPTIVE PROFILE)
+      if (profileMode === "adaptive" && repositoryMap !== null) {
+        telemetry.recordMethod("lexical_bm25");
+        try {
+          const candidatePaths = [
+            ...allowedScope.writePaths,
+            ...allowedScope.readPaths,
+            ...repositoryMap.entries.map((e) => e.path),
+          ];
+          const uniquePaths = [...new Set(candidatePaths)];
+          const lexicalIndex = await getOrBuildLexicalChunkIndex(
+            workspaceId,
+            repositoryMap.indexRevision,
+            uniquePaths,
+            fileReader,
+          );
+
+          const qTokens = tokenizeForBm25(query.text);
+          if (qTokens.length > 0 && lexicalIndex.chunks.length > 0) {
+            const scoredChunks = lexicalIndex.chunks
+              .map((chunk) => {
+                const score = scoreDocumentBm25({
+                  queryTokens: qTokens,
+                  docTokens: chunk.tokens,
+                  docFrequencies: lexicalIndex.docFrequencies,
+                  corpusSize: lexicalIndex.chunks.length,
+                  avgDocTokens: lexicalIndex.avgDocTokens,
+                });
+                return { chunk, score };
+              })
+              .filter((entry) => entry.score > 0.05)
+              .sort((a, b) => b.score - a.score)
+              .slice(0, 3); // top 3 lexical chunks per query
+
+            for (const { chunk, score } of scoredChunks) {
+              const chunkId = `lexical-chunk:${chunk.path}:${chunk.startLine}-${chunk.endLine}`;
+              if (seen.has(chunkId)) continue;
+              seen.add(chunkId);
+
+              const text = [
+                `# Lexical BM25 match (${chunk.path}:${chunk.startLine}-${chunk.endLine})`,
+                chunk.content,
+              ].join("\n");
+              const hash = computeContentHash(text);
+              const fragment: ContextFragment = {
+                id: chunkId,
+                kind: "code",
+                contentRef: {
+                  hash,
+                  uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
+                  mediaType: "text/plain",
+                  bytes: BigInt(new TextEncoder().encode(text).byteLength) as ContextFragment["contentRef"]["bytes"],
+                },
+                textContent: text,
+                source: {
+                  uri: `workspace://${chunk.path}`,
+                  producer: "terminus-control-lexical-retrieval",
+                  producerVersion: "v1",
+                  observedAt,
+                  observedBy: "control",
+                  evidenceRefs: [],
+                },
+                sourceVersion: chunk.sourceSha256,
+                authority: 50,
+                priority: 50,
+                trust: "derived",
+                confidentiality: "workspace",
+                injectionRisk: "low",
+                exactness: "exact",
+                scope: {
+                  workspaceId: null,
+                  sessionId: sessionId as ContextFragment["scope"]["sessionId"],
+                  taskId: taskId as ContextFragment["scope"]["taskId"],
+                  pathPatterns: [chunk.path],
+                },
+                freshness: { observedAt, sourceVersion: chunk.sourceSha256, stale: false, staleReason: null },
+                dependencies: [],
+                invalidation: [{ kind: "file_changed", selector: chunk.path }],
+                estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(text.length / 4)) },
+                selectionFeatures: {
+                  relevance: Math.min(0.95, 0.5 + score * 0.1),
+                  novelty: 0.8,
+                  coverage: 0.75,
+                  uncertaintyReduction: 0.7,
+                  riskReduction: 0.5,
+                  modelCompatibility: 1,
+                  redundancyPenalty: 0,
+                  injectionPenalty: 0,
+                },
+              };
+
+              results.push({
+                fragment,
+                method: "lexical_bm25",
+                rawScore: score,
+                rerankedScore: score,
+                sourceVersion: chunk.sourceSha256,
+                reason: `lexical BM25 match for query: ${query.reason}`,
+              });
+            }
+          }
+        } catch {
+          // Fail soft if lexical retrieval is unavailable
+          telemetry.recordFailure();
+        }
+      }
+    }
+
+    const elapsed = performance.now() - startTime;
+    telemetry.recordLatency(elapsed);
+    return results;
+  };
+
+  return {
+    telemetry,
+    retrieve: (queries) => retrieve(queries),
+    expandForGaps: (gaps) => retrieve(gaps.map((gap) => ({
+      text: gap.requirement,
+      reason: `evidence gap: ${gap.requirementId}`,
+      suggestedMethods: ["lexical_bm25"],
+    }))),
+  };
+}

--- a/mini-services/terminus-control/src/agent/retrieval-pipeline.ts
+++ b/mini-services/terminus-control/src/agent/retrieval-pipeline.ts
@@ -5,13 +5,13 @@
  * - Extracted from terminus-control index.ts
  * - Exact-symbol lookup via kernel CodeIntelligenceRpc
  * - Chunked lexical BM25 candidate (overlap-aware, token-normalized, kernel-read)
- * - Cache keyed by workspace and repository-map revision
- * - Fail-soft error handling
+ * - Cache keyed by workspace and repository-map revision (bounded LRU, in-flight dedup)
+ * - Fail-soft error handling with guaranteed latency recording
  * - Comprehensive per-turn telemetry collection
  * - Strict profile gating: lexical retrieval active only in adaptive profile
  */
 
-import { randomUUID, createHash } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import type {
   ContextFragment,
   ModelKey,
@@ -27,8 +27,6 @@ import {
   computeAvgDocTokens,
 } from "@terminus/context-ir";
 import type {
-  CompileInput,
-  EvidenceGap,
   RetrievalMethod,
   RetrievalPipeline,
   RetrievalQuery,
@@ -76,11 +74,11 @@ export class RetrievalTelemetryCollector {
   private readonly hydratedFiles = new Set<string>();
   private totalBytesRead = 0;
   private totalTokensRead = 0;
-  private admittedFragments = new Set<string>();
+  private readonly admittedFragments = new Set<string>();
   private latencyMs = 0;
   private failures = 0;
   private readonly retrievedFilesSet = new Set<string>();
-  private changedOrVerified = new Set<string>();
+  private readonly changedOrVerified = new Set<string>();
 
   recordQuery(query: RetrievalQuery): void {
     this.queriesList.push({
@@ -108,8 +106,11 @@ export class RetrievalTelemetryCollector {
     this.totalTokensRead += tokens;
   }
 
-  recordAdmittedFragment(fragmentId: string): void {
+  recordAdmittedFragment(fragmentId: string, path?: string): void {
     this.admittedFragments.add(fragmentId);
+    if (path && path.length > 0) {
+      this.retrievedFilesSet.add(path);
+    }
   }
 
   recordAdmittedFragments(fragmentIds: readonly string[]): void {
@@ -169,23 +170,26 @@ export interface LexicalChunkIndex {
   readonly avgDocTokens: number;
 }
 
-// Global cache for workspace lexical chunk indices: key = `${workspaceId}:${revision}`
+// Bounded LRU cache for workspace lexical chunk indices: key = `${workspaceId}:${revision}`
+const MAX_CACHED_INDICES = 16;
 const LEXICAL_INDEX_CACHE = new Map<string, LexicalChunkIndex>();
+const IN_FLIGHT_INDEX_BUILDS = new Map<string, Promise<LexicalChunkIndex>>();
 
-export function clearLexicalIndexCache(): void {
+export const clearLexicalIndexCache = (): void => {
   LEXICAL_INDEX_CACHE.clear();
-}
+  IN_FLIGHT_INDEX_BUILDS.clear();
+};
 
 /**
  * Split source code into bounded, overlap-aware chunks.
  */
-export function chunkSourceLines(
+export const chunkSourceLines = (
   path: string,
   content: string,
   sourceSha256: string | null,
   chunkLines = 60,
   overlapLines = 15,
-): readonly SourceChunk[] {
+): readonly SourceChunk[] => {
   const lines = content.split("\n");
   if (lines.length === 0 || content.trim().length === 0) return [];
 
@@ -210,59 +214,80 @@ export function chunkSourceLines(
   }
 
   return chunks;
-}
+};
 
 /**
  * Build or retrieve cached lexical chunk index for a workspace revision.
  * Reads files through the kernel WorkspaceFileReader exclusively.
+ * Deduplicates in-flight builds and bounds memory to MAX_CACHED_INDICES.
  */
-export async function getOrBuildLexicalChunkIndex(
+export const getOrBuildLexicalChunkIndex = async (
   workspaceId: string,
   revision: string,
   candidatePaths: readonly string[],
   fileReader: WorkspaceFileReader,
   maxFilesToIndex = 30,
-): Promise<LexicalChunkIndex> {
+): Promise<LexicalChunkIndex> => {
   const cacheKey = `${workspaceId}:${revision}`;
   const existing = LEXICAL_INDEX_CACHE.get(cacheKey);
   if (existing !== undefined) {
     return existing;
   }
 
-  const chunks: SourceChunk[] = [];
-  const pathsToIndex = candidatePaths.slice(0, maxFilesToIndex);
-
-  for (const path of pathsToIndex) {
-    try {
-      const readResult = await fileReader({
-        path,
-        startLine: 1,
-        endLine: 400, // index first 400 lines of top candidate files
-      });
-      if (readResult.content !== null && readResult.content.length > 0) {
-        const fileChunks = chunkSourceLines(path, readResult.content, readResult.fileSha256);
-        chunks.push(...fileChunks);
-      }
-    } catch {
-      // Fail-soft: skip unreadable files
-    }
+  const inFlight = IN_FLIGHT_INDEX_BUILDS.get(cacheKey);
+  if (inFlight !== undefined) {
+    return inFlight;
   }
 
-  const tokenizedDocs = chunks.map((c) => c.tokens);
-  const docFrequencies = computeDocumentFrequencies(tokenizedDocs);
-  const avgDocTokens = computeAvgDocTokens(tokenizedDocs);
+  const buildPromise = (async () => {
+    const chunks: SourceChunk[] = [];
+    const pathsToIndex = candidatePaths.slice(0, maxFilesToIndex);
 
-  const index: LexicalChunkIndex = {
-    workspaceId,
-    revision,
-    chunks,
-    docFrequencies,
-    avgDocTokens,
-  };
+    for (const path of pathsToIndex) {
+      try {
+        const readResult = await fileReader({
+          path,
+          startLine: 1,
+          endLine: 400, // index first 400 lines of top candidate files
+        });
+        if (readResult.content !== null && readResult.content.length > 0) {
+          const fileChunks = chunkSourceLines(path, readResult.content, readResult.fileSha256);
+          chunks.push(...fileChunks);
+        }
+      } catch {
+        // Fail-soft: skip unreadable files
+      }
+    }
 
-  LEXICAL_INDEX_CACHE.set(cacheKey, index);
-  return index;
-}
+    const tokenizedDocs = chunks.map((c) => c.tokens);
+    const docFrequencies = computeDocumentFrequencies(tokenizedDocs);
+    const avgDocTokens = computeAvgDocTokens(tokenizedDocs);
+
+    const index: LexicalChunkIndex = {
+      workspaceId,
+      revision,
+      chunks,
+      docFrequencies,
+      avgDocTokens,
+    };
+
+    if (LEXICAL_INDEX_CACHE.size >= MAX_CACHED_INDICES) {
+      const oldestKey = LEXICAL_INDEX_CACHE.keys().next().value;
+      if (oldestKey !== undefined) {
+        LEXICAL_INDEX_CACHE.delete(oldestKey);
+      }
+    }
+    LEXICAL_INDEX_CACHE.set(cacheKey, index);
+    return index;
+  })();
+
+  IN_FLIGHT_INDEX_BUILDS.set(cacheKey, buildPromise);
+  try {
+    return await buildPromise;
+  } finally {
+    IN_FLIGHT_INDEX_BUILDS.delete(cacheKey);
+  }
+};
 
 export interface KernelRetrievalPipelineOptions {
   readonly clients: KernelUdsClients;
@@ -278,28 +303,157 @@ export interface KernelRetrievalPipelineOptions {
   readonly telemetry?: RetrievalTelemetryCollector;
 }
 
-export function mapRetrievalMethod(method: string): RetrievalMethod {
-  switch (method) {
-    case "tree_sitter":
-    case "lsp":
-    case "graph":
-      return method === "graph" ? "dependency_graph" : method;
-    case "lexical_bm25":
-      return method;
-    case "exact_path_symbol":
-      return method;
-    default:
-      return "lexical_bm25";
+export const mapRetrievalMethod = (method: string): RetrievalMethod => {
+  if (method === "exact_path_symbol" || method === "lexical_bm25") {
+    return method;
   }
-}
+  if (method === "graph") {
+    return "dependency_graph";
+  }
+  if (method === "tree_sitter" || method === "lsp") {
+    return method;
+  }
+  return "lexical_bm25";
+};
+
+/** Build an exact-symbol context fragment from a hydrated search hit. */
+const buildExactSymbolFragment = (
+  id: string,
+  hit: { readonly path: string; readonly line: number; readonly symbol: string | null; readonly method: string },
+  hydratedSpan: { readonly fragmentText?: string; readonly fileSha256?: string | null } | null,
+  observedAt: Rfc3339Timestamp,
+  sessionId: string,
+  taskId: string,
+  modelKey: ModelKey,
+  query: RetrievalQuery,
+): ContextFragment => {
+  const text = hydratedSpan?.fragmentText ?? [
+    "# Code intelligence result",
+    `path: ${hit.path}`,
+    `line: ${hit.line}`,
+    `symbol: ${hit.symbol}`,
+    `index method: ${hit.method}`,
+    "(source span unavailable — request read for implementation)",
+  ].join("\n");
+  const hash = computeContentHash(text);
+  return {
+    id,
+    kind: "code",
+    contentRef: {
+      hash,
+      uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
+      mediaType: "text/plain",
+      bytes: BigInt(new TextEncoder().encode(text).byteLength) as ContextFragment["contentRef"]["bytes"],
+    },
+    textContent: text,
+    source: {
+      uri: `workspace://${hit.path}`,
+      producer: "terminus-kernel-code-intel",
+      producerVersion: "v1",
+      observedAt,
+      observedBy: "kernel",
+      evidenceRefs: [],
+    },
+    sourceVersion: null,
+    authority: 55,
+    priority: 55,
+    trust: "derived",
+    confidentiality: "workspace",
+    injectionRisk: "low",
+    exactness: "recoverable_by_reference",
+    scope: {
+      workspaceId: null,
+      sessionId: sessionId as ContextFragment["scope"]["sessionId"],
+      taskId: taskId as ContextFragment["scope"]["taskId"],
+      pathPatterns: [hit.path],
+    },
+    freshness: { observedAt, sourceVersion: null, stale: false, staleReason: null },
+    dependencies: [],
+    invalidation: [{ kind: "file_changed", selector: hit.path }],
+    estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(text.length / 4)) },
+    selectionFeatures: {
+      relevance: query.suggestedMethods.includes(mapRetrievalMethod(hit.method)) ? 0.9 : 0.6,
+      novelty: 0.7,
+      coverage: 0.8,
+      uncertaintyReduction: 0.7,
+      riskReduction: 0.5,
+      modelCompatibility: 1,
+      redundancyPenalty: 0,
+      injectionPenalty: 0,
+    },
+  };
+};
+
+/** Build a lexical chunk context fragment from scored chunk. */
+const buildLexicalChunkFragment = (
+  chunkId: string,
+  chunk: SourceChunk,
+  score: number,
+  observedAt: Rfc3339Timestamp,
+  sessionId: string,
+  taskId: string,
+  modelKey: ModelKey,
+): ContextFragment => {
+  const text = [
+    `# Lexical BM25 match (${chunk.path}:${chunk.startLine}-${chunk.endLine})`,
+    chunk.content,
+  ].join("\n");
+  const hash = computeContentHash(text);
+  return {
+    id: chunkId,
+    kind: "code",
+    contentRef: {
+      hash,
+      uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
+      mediaType: "text/plain",
+      bytes: BigInt(new TextEncoder().encode(text).byteLength) as ContextFragment["contentRef"]["bytes"],
+    },
+    textContent: text,
+    source: {
+      uri: `workspace://${chunk.path}`,
+      producer: "terminus-control-lexical-retrieval",
+      producerVersion: "v1",
+      observedAt,
+      observedBy: "control",
+      evidenceRefs: [],
+    },
+    sourceVersion: chunk.sourceSha256,
+    authority: 50,
+    priority: 50,
+    trust: "derived",
+    confidentiality: "workspace",
+    injectionRisk: "low",
+    exactness: "exact",
+    scope: {
+      workspaceId: null,
+      sessionId: sessionId as ContextFragment["scope"]["sessionId"],
+      taskId: taskId as ContextFragment["scope"]["taskId"],
+      pathPatterns: [chunk.path],
+    },
+    freshness: { observedAt, sourceVersion: chunk.sourceSha256, stale: false, staleReason: null },
+    dependencies: [],
+    invalidation: [{ kind: "file_changed", selector: chunk.path }],
+    estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(text.length / 4)) },
+    selectionFeatures: {
+      relevance: Math.min(0.95, 0.5 + score * 0.1),
+      novelty: 0.8,
+      coverage: 0.75,
+      uncertaintyReduction: 0.7,
+      riskReduction: 0.5,
+      modelCompatibility: 1,
+      redundancyPenalty: 0,
+      injectionPenalty: 0,
+    },
+  };
+};
 
 /**
  * Creates the kernel retrieval pipeline with per-turn telemetry and optional
  * chunked lexical retrieval candidate in adaptive profile mode.
  */
-export function kernelRetrievalPipeline(
+export const kernelRetrievalPipeline = (
   options: KernelRetrievalPipelineOptions,
-): RetrievalPipeline & { readonly telemetry: RetrievalTelemetryCollector } {
+): RetrievalPipeline & { readonly telemetry: RetrievalTelemetryCollector } => {
   const {
     clients,
     buildContext,
@@ -340,6 +494,9 @@ export function kernelRetrievalPipeline(
         maxBytes: 48 * 1_024,
         expectedSha256: "",
       });
+      if (read.truncated) {
+        telemetry.recordFailure();
+      }
       const decoded = new TextDecoder("utf-8", { fatal: false }).decode(read.modelProjectionUtf8);
       const byteCount = read.modelProjectionUtf8.byteLength;
       const tokenCount = Math.max(1, Math.ceil(decoded.length / 4));
@@ -358,8 +515,16 @@ export function kernelRetrievalPipeline(
   const repositoryMapFragment = repositoryMap === null || repositoryMap.entries.length === 0
     ? null
     : (() => {
+        // Prioritize allowed task scope paths before slicing to budget
+        const scopeMatchedEntries = repositoryMap.entries.filter((entry) =>
+          allowedScope.writePaths.some((wp) => entry.path.startsWith(wp.replace(/\/?\*\*?$/, "")))
+          || allowedScope.readPaths.some((rp) => entry.path.startsWith(rp.replace(/\/?\*\*?$/, ""))),
+        );
+        const otherEntries = repositoryMap.entries.filter((entry) => !scopeMatchedEntries.includes(entry));
+        const prioritizedEntries = [...scopeMatchedEntries, ...otherEntries];
+
         const selection = selectTaskScopedRepositoryMap(
-          repositoryMap.entries
+          prioritizedEntries
             .slice(0, 200 * 8)
             .map((entry) => ({ path: entry.path, symbols: entry.symbols })),
           { readPaths: allowedScope.readPaths, writePaths: allowedScope.writePaths },
@@ -428,244 +593,175 @@ export function kernelRetrievalPipeline(
         return fragment;
       })();
 
+  const executeExactLookup = async (
+    query: RetrievalQuery,
+    seen: Set<string>,
+    results: RetrievalResult[],
+  ): Promise<void> => {
+    let recordedTruncation = false;
+    try {
+      const baseContext = await buildContext();
+      telemetry.recordMethod("exact_path_symbol");
+      const response = await clients.codeIntel.Search({
+        context: {
+          ...baseContext,
+          requestId: randomUUID(),
+          idempotencyKey: `code-search:${randomUUID()}`,
+        },
+        workspaceId,
+        query: query.text,
+        limit: 5,
+      });
+
+      if (response.truncated) {
+        recordedTruncation = true;
+        telemetry.recordFailure();
+        throw new Error(
+          `code-intelligence retrieval truncated for query ${JSON.stringify(query.text)}${response.continuation === undefined ? " without a continuation token" : "; continuation RPC is unavailable"}`,
+        );
+      }
+
+      const hits = response.results;
+      telemetry.recordHits(hits.length, hits.length > 0);
+
+      for (const hit of hits) {
+        const id = `kernel-code:${hit.path}:${hit.line}:${hit.symbol}`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+
+        const searchHit: SearchHit = {
+          path: hit.path,
+          line: hit.line,
+          symbol: typeof hit.symbol === "string" && hit.symbol.length > 0 ? hit.symbol : null,
+          method: hit.method,
+        };
+        const hydratedSpan = await hydrateSearchHit(searchHit, fileReader);
+        const fragment = buildExactSymbolFragment(
+          id,
+          hit,
+          hydratedSpan,
+          observedAt,
+          sessionId,
+          taskId,
+          modelKey,
+          query,
+        );
+        telemetry.recordAdmittedFragment(fragment.id, hit.path);
+        results.push({
+          fragment,
+          method: mapRetrievalMethod(hit.method),
+          rawScore: 1,
+          rerankedScore: 1,
+          sourceVersion: hydratedSpan?.fileSha256 ?? null,
+          reason: query.reason,
+        });
+      }
+    } catch (error) {
+      if (!recordedTruncation) {
+        telemetry.recordFailure();
+      }
+      if (profileMode === "minimal") {
+        throw error;
+      }
+    }
+  };
+
+  const executeLexicalLookup = async (
+    query: RetrievalQuery,
+    seen: Set<string>,
+    results: RetrievalResult[],
+  ): Promise<void> => {
+    if (profileMode !== "adaptive" || repositoryMap === null) return;
+    telemetry.recordMethod("lexical_bm25");
+    try {
+      const candidatePaths = [
+        ...allowedScope.writePaths,
+        ...allowedScope.readPaths,
+        ...repositoryMap.entries.map((e) => e.path),
+      ];
+      const uniquePaths = [...new Set(candidatePaths)];
+      const lexicalIndex = await getOrBuildLexicalChunkIndex(
+        workspaceId,
+        repositoryMap.indexRevision,
+        uniquePaths,
+        fileReader,
+      );
+
+      const qTokens = tokenizeForBm25(query.text);
+      if (qTokens.length === 0 || lexicalIndex.chunks.length === 0) return;
+
+      const scoredChunks = lexicalIndex.chunks
+        .map((chunk) => ({
+          chunk,
+          score: scoreDocumentBm25({
+            queryTokens: qTokens,
+            docTokens: chunk.tokens,
+            docFrequencies: lexicalIndex.docFrequencies,
+            corpusSize: lexicalIndex.chunks.length,
+            avgDocTokens: lexicalIndex.avgDocTokens,
+          }),
+        }))
+        .filter((entry) => entry.score > 0.05)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 3);
+
+      for (const { chunk, score } of scoredChunks) {
+        const chunkId = `lexical-chunk:${chunk.path}:${chunk.startLine}-${chunk.endLine}`;
+        if (seen.has(chunkId)) continue;
+        seen.add(chunkId);
+
+        const fragment = buildLexicalChunkFragment(
+          chunkId,
+          chunk,
+          score,
+          observedAt,
+          sessionId,
+          taskId,
+          modelKey,
+        );
+        telemetry.recordAdmittedFragment(fragment.id, chunk.path);
+        results.push({
+          fragment,
+          method: "lexical_bm25",
+          rawScore: score,
+          rerankedScore: score,
+          sourceVersion: chunk.sourceSha256,
+          reason: `lexical BM25 match for query: ${query.reason}`,
+        });
+      }
+    } catch {
+      telemetry.recordFailure();
+    }
+  };
+
   const retrieve = async (queries: readonly RetrievalQuery[]): Promise<readonly RetrievalResult[]> => {
     const startTime = performance.now();
-    // Repository map fragment is labeled as exact_path_symbol (stopped labeling as semantic)
-    const results: RetrievalResult[] = repositoryMapFragment === null
-      ? []
-      : [{
-          fragment: repositoryMapFragment,
-          method: "exact_path_symbol",
-          rawScore: 0.8,
-          rerankedScore: 0.8,
-          sourceVersion: repositoryMapFragment.sourceVersion,
-          reason: "kernel repository map",
-        }];
+    const results: RetrievalResult[] = [];
+    if (repositoryMapFragment !== null) {
+      telemetry.recordAdmittedFragment(repositoryMapFragment.id);
+      results.push({
+        fragment: repositoryMapFragment,
+        method: "exact_path_symbol",
+        rawScore: 0.8,
+        rerankedScore: 0.8,
+        sourceVersion: repositoryMapFragment.sourceVersion,
+        reason: "kernel repository map",
+      });
+    }
 
     const seen = new Set<string>();
 
-    for (const query of queries) {
-      telemetry.recordQuery(query);
-
-      // 1. Exact-symbol lookup via kernel CodeIntelligenceRpc
-      try {
-        const baseContext = await buildContext();
-        telemetry.recordMethod("exact_path_symbol");
-        const response = await clients.codeIntel.Search({
-          context: {
-            ...baseContext,
-            requestId: randomUUID(),
-            idempotencyKey: `code-search:${randomUUID()}`,
-          },
-          workspaceId,
-          query: query.text,
-          limit: 5,
-        });
-
-        if (response.truncated) {
-          telemetry.recordFailure();
-          throw new Error(
-            `code-intelligence retrieval truncated for query ${JSON.stringify(query.text)}${response.continuation === undefined ? " without a continuation token" : "; continuation RPC is unavailable"}`,
-          );
-        }
-
-        const hits = response.results;
-        telemetry.recordHits(hits.length, hits.length > 0);
-
-        for (const hit of hits) {
-          const id = `kernel-code:${hit.path}:${hit.line}:${hit.symbol}`;
-          if (seen.has(id)) continue;
-          seen.add(id);
-
-          const searchHit: SearchHit = {
-            path: hit.path,
-            line: hit.line,
-            symbol: typeof hit.symbol === "string" && hit.symbol.length > 0 ? hit.symbol : null,
-            method: hit.method,
-          };
-          const hydratedSpan = await hydrateSearchHit(searchHit, fileReader);
-          const text = hydratedSpan?.fragmentText ?? [
-            `# Code intelligence result`,
-            `path: ${hit.path}`,
-            `line: ${hit.line}`,
-            `symbol: ${hit.symbol}`,
-            `index method: ${hit.method}`,
-            `(source span unavailable — request read for implementation)`,
-          ].join("\n");
-          const hash = computeContentHash(text);
-          const fragment: ContextFragment = {
-            id,
-            kind: "code",
-            contentRef: {
-              hash,
-              uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
-              mediaType: "text/plain",
-              bytes: BigInt(new TextEncoder().encode(text).byteLength) as ContextFragment["contentRef"]["bytes"],
-            },
-            textContent: text,
-            source: {
-              uri: `workspace://${hit.path}`,
-              producer: "terminus-kernel-code-intel",
-              producerVersion: "v1",
-              observedAt,
-              observedBy: "kernel",
-              evidenceRefs: [],
-            },
-            sourceVersion: null,
-            authority: 55,
-            priority: 55,
-            trust: "derived",
-            confidentiality: "workspace",
-            injectionRisk: "low",
-            exactness: "recoverable_by_reference",
-            scope: {
-              workspaceId: null,
-              sessionId: sessionId as ContextFragment["scope"]["sessionId"],
-              taskId: taskId as ContextFragment["scope"]["taskId"],
-              pathPatterns: [hit.path],
-            },
-            freshness: { observedAt, sourceVersion: null, stale: false, staleReason: null },
-            dependencies: [],
-            invalidation: [{ kind: "file_changed", selector: hit.path }],
-            estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(text.length / 4)) },
-            selectionFeatures: {
-              relevance: query.suggestedMethods.includes(mapRetrievalMethod(hit.method)) ? 0.9 : 0.6,
-              novelty: 0.7,
-              coverage: 0.8,
-              uncertaintyReduction: 0.7,
-              riskReduction: 0.5,
-              modelCompatibility: 1,
-              redundancyPenalty: 0,
-              injectionPenalty: 0,
-            },
-          };
-          results.push({
-            fragment,
-            method: mapRetrievalMethod(hit.method),
-            rawScore: 1,
-            rerankedScore: 1,
-            sourceVersion: hydratedSpan?.fileSha256 ?? null,
-            reason: query.reason,
-          });
-        }
-      } catch (error) {
-        telemetry.recordFailure();
-        if (profileMode === "minimal") {
-          throw error;
-        }
+    try {
+      for (const query of queries) {
+        telemetry.recordQuery(query);
+        await executeExactLookup(query, seen, results);
+        await executeLexicalLookup(query, seen, results);
       }
-
-      // 2. Candidate: Chunked lexical BM25 retrieval (ACTIVE ONLY IN ADAPTIVE PROFILE)
-      if (profileMode === "adaptive" && repositoryMap !== null) {
-        telemetry.recordMethod("lexical_bm25");
-        try {
-          const candidatePaths = [
-            ...allowedScope.writePaths,
-            ...allowedScope.readPaths,
-            ...repositoryMap.entries.map((e) => e.path),
-          ];
-          const uniquePaths = [...new Set(candidatePaths)];
-          const lexicalIndex = await getOrBuildLexicalChunkIndex(
-            workspaceId,
-            repositoryMap.indexRevision,
-            uniquePaths,
-            fileReader,
-          );
-
-          const qTokens = tokenizeForBm25(query.text);
-          if (qTokens.length > 0 && lexicalIndex.chunks.length > 0) {
-            const scoredChunks = lexicalIndex.chunks
-              .map((chunk) => {
-                const score = scoreDocumentBm25({
-                  queryTokens: qTokens,
-                  docTokens: chunk.tokens,
-                  docFrequencies: lexicalIndex.docFrequencies,
-                  corpusSize: lexicalIndex.chunks.length,
-                  avgDocTokens: lexicalIndex.avgDocTokens,
-                });
-                return { chunk, score };
-              })
-              .filter((entry) => entry.score > 0.05)
-              .sort((a, b) => b.score - a.score)
-              .slice(0, 3); // top 3 lexical chunks per query
-
-            for (const { chunk, score } of scoredChunks) {
-              const chunkId = `lexical-chunk:${chunk.path}:${chunk.startLine}-${chunk.endLine}`;
-              if (seen.has(chunkId)) continue;
-              seen.add(chunkId);
-
-              const text = [
-                `# Lexical BM25 match (${chunk.path}:${chunk.startLine}-${chunk.endLine})`,
-                chunk.content,
-              ].join("\n");
-              const hash = computeContentHash(text);
-              const fragment: ContextFragment = {
-                id: chunkId,
-                kind: "code",
-                contentRef: {
-                  hash,
-                  uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
-                  mediaType: "text/plain",
-                  bytes: BigInt(new TextEncoder().encode(text).byteLength) as ContextFragment["contentRef"]["bytes"],
-                },
-                textContent: text,
-                source: {
-                  uri: `workspace://${chunk.path}`,
-                  producer: "terminus-control-lexical-retrieval",
-                  producerVersion: "v1",
-                  observedAt,
-                  observedBy: "control",
-                  evidenceRefs: [],
-                },
-                sourceVersion: chunk.sourceSha256,
-                authority: 50,
-                priority: 50,
-                trust: "derived",
-                confidentiality: "workspace",
-                injectionRisk: "low",
-                exactness: "exact",
-                scope: {
-                  workspaceId: null,
-                  sessionId: sessionId as ContextFragment["scope"]["sessionId"],
-                  taskId: taskId as ContextFragment["scope"]["taskId"],
-                  pathPatterns: [chunk.path],
-                },
-                freshness: { observedAt, sourceVersion: chunk.sourceSha256, stale: false, staleReason: null },
-                dependencies: [],
-                invalidation: [{ kind: "file_changed", selector: chunk.path }],
-                estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(text.length / 4)) },
-                selectionFeatures: {
-                  relevance: Math.min(0.95, 0.5 + score * 0.1),
-                  novelty: 0.8,
-                  coverage: 0.75,
-                  uncertaintyReduction: 0.7,
-                  riskReduction: 0.5,
-                  modelCompatibility: 1,
-                  redundancyPenalty: 0,
-                  injectionPenalty: 0,
-                },
-              };
-
-              results.push({
-                fragment,
-                method: "lexical_bm25",
-                rawScore: score,
-                rerankedScore: score,
-                sourceVersion: chunk.sourceSha256,
-                reason: `lexical BM25 match for query: ${query.reason}`,
-              });
-            }
-          }
-        } catch {
-          // Fail soft if lexical retrieval is unavailable
-          telemetry.recordFailure();
-        }
-      }
+      return results;
+    } finally {
+      const elapsed = performance.now() - startTime;
+      telemetry.recordLatency(elapsed);
     }
-
-    const elapsed = performance.now() - startTime;
-    telemetry.recordLatency(elapsed);
-    return results;
   };
 
   return {
@@ -677,4 +773,4 @@ export function kernelRetrievalPipeline(
       suggestedMethods: ["lexical_bm25"],
     }))),
   };
-}
+};

--- a/mini-services/terminus-control/src/index.ts
+++ b/mini-services/terminus-control/src/index.ts
@@ -589,6 +589,11 @@ import {
   type WorkspaceFileReader,
 } from "./agent/retrieval-hydrator.js";
 import {
+  kernelRetrievalPipeline,
+  mapRetrievalMethod,
+  RetrievalTelemetryCollector,
+} from "./agent/retrieval-pipeline.js";
+import {
   VerificationRepairController,
   buildRepairContext,
   normalizeFailure,
@@ -13394,264 +13399,9 @@ async function discoverRepositorySignals(
   };
 }
 
-/** Kernel-backed code-intelligence retrieval for the live compiler path. */
-function kernelRetrievalPipeline(
-  clients: KernelUdsClients,
-  buildContext: () => Promise<RequestContext>,
-  observedAt: Rfc3339Timestamp,
-  modelKey: ModelKey,
-  sessionId: string,
-  taskId: string,
-  workspaceId: string,
-  repositoryMap: RepositoryMapObservation | null,
-  /** The task contract's allowed scope; ranks the repository map. */
-  allowedScope: { readonly readPaths: readonly string[]; readonly writePaths: readonly string[] }
-    = { readPaths: [], writePaths: [] },
-): RetrievalPipeline {
-  const fileReader: WorkspaceFileReader = async ({ path, startLine, endLine }) => {
-    try {
-      const baseContext = await buildContext();
-      const read = await clients.files.Read({
-        context: {
-          ...baseContext,
-          requestId: randomUUID(),
-          idempotencyKey: `code-hydrate:${randomUUID()}`,
-        },
-        intent: {
-          userIntentRef: "retrieval-hydration",
-          taskContractHash: "",
-          trustLabel: "derived",
-          confidentialityLabel: "workspace",
-          taintSources: [],
-          policyProfileId: "secure-local-default",
-          expectedEffectClass: "read_local",
-        },
-        path: { workspaceId, relativePath: path },
-        mode: "ranges",
-        ranges: [{ startLine, endLine }],
-        symbols: [],
-        maxBytes: 48 * 1_024,
-        expectedSha256: "",
-      });
-      return {
-        content: new TextDecoder("utf-8", { fatal: false }).decode(read.modelProjectionUtf8),
-        fileSha256: read.sourceVersion?.sha256 ?? null,
-        totalLines: null,
-      };
-    } catch {
-      // File unreadable (deleted/moved/unreadable since indexing): the
-      // caller falls back to the metadata-only representation.
-      return { content: null, fileSha256: null, totalLines: null };
-    }
-  };
-  const repositoryMapFragment = repositoryMap === null || repositoryMap.entries.length === 0
-    ? null
-    : (() => {
-        // Task-scoped and token-capped: files the contract may write come
-        // first, then files it may read, then the rest of the index — and the
-        // whole fragment stops at REPOSITORY_MAP_TOKEN_BUDGET instead of the
-        // 16-18k tokens the alphabetically-first 200 files used to cost.
-        const selection = selectTaskScopedRepositoryMap(
-          repositoryMap.entries
-            .slice(0, REPOSITORY_MAP_CONTEXT_ENTRY_LIMIT * 8)
-            .map((entry) => ({ path: entry.path, symbols: entry.symbols })),
-          { readPaths: allowedScope.readPaths, writePaths: allowedScope.writePaths },
-        );
-        const entries = selection.entries;
-        const rendered = buildRepositoryMapFragment(entries, {
-          maxEntries: entries.length,
-          omittedEntries: Math.max(0, repositoryMap.entries.length - entries.length),
-          continuationToken: repositoryMap.continuationToken,
-          title: "Kernel repository map",
-        });
-        const hash = computeContentHash(rendered.text);
-        const bytes = new TextEncoder().encode(rendered.text).byteLength;
-        const pathPatterns = entries.map((entry) => entry.path);
-        const fragment: ContextFragment = {
-          id: `kernel-repository-map:${hash}`,
-          kind: "code",
-          contentRef: {
-            hash,
-            uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
-            mediaType: "text/plain",
-            bytes: BigInt(bytes) as ContextFragment["contentRef"]["bytes"],
-          },
-          textContent: rendered.text,
-          source: {
-            uri: `workspace://${workspaceId}/repository-map`,
-            producer: "terminus-kernel-code-intel",
-            producerVersion: "v1",
-            observedAt,
-            observedBy: "kernel",
-            evidenceRefs: [],
-          },
-          sourceVersion: repositoryMap.indexRevision,
-          authority: 55,
-          priority: 60,
-          trust: "derived",
-          confidentiality: "workspace",
-          injectionRisk: "low",
-          exactness: "semantics_preserving",
-          scope: {
-            workspaceId: workspaceId as ContextFragment["scope"]["workspaceId"],
-            sessionId: sessionId as ContextFragment["scope"]["sessionId"],
-            taskId: taskId as ContextFragment["scope"]["taskId"],
-            pathPatterns,
-          },
-          freshness: {
-            observedAt,
-            sourceVersion: repositoryMap.indexRevision,
-            stale: false,
-            staleReason: null,
-          },
-          dependencies: [],
-          invalidation: [{ kind: "file_changed", selector: `workspace://${workspaceId}` }],
-          estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(rendered.text.length / 4)) },
-          selectionFeatures: {
-            relevance: 0.65,
-            novelty: 0.9,
-            coverage: 0.95,
-            uncertaintyReduction: 0.85,
-            riskReduction: 0.55,
-            modelCompatibility: 1,
-            redundancyPenalty: 0,
-            injectionPenalty: 0,
-          },
-        };
-        return fragment;
-      })();
-  const retrieve = async (queries: readonly RetrievalQuery[]): Promise<readonly RetrievalResult[]> => {
-    const results: RetrievalResult[] = repositoryMapFragment === null
-      ? []
-      : [{
-          fragment: repositoryMapFragment,
-          method: "semantic",
-          rawScore: 0.8,
-          rerankedScore: 0.8,
-          sourceVersion: repositoryMapFragment.sourceVersion,
-          reason: "kernel repository map",
-        }];
-    const seen = new Set<string>();
-    for (const query of queries) {
-      const baseContext = await buildContext();
-      const response = await clients.codeIntel.Search({
-        context: {
-          ...baseContext,
-          requestId: randomUUID(),
-          idempotencyKey: `code-search:${randomUUID()}`,
-        },
-        workspaceId,
-        query: query.text,
-        limit: 5,
-      });
-      if (response.truncated) {
-        throw new Error(
-          `code-intelligence retrieval truncated for query ${JSON.stringify(query.text)}${response.continuation === undefined ? " without a continuation token" : "; continuation RPC is unavailable"}`,
-        );
-      }
-      for (const hit of response.results) {
-        const id = `kernel-code:${hit.path}:${hit.line}:${hit.symbol}`;
-        if (seen.has(id)) continue;
-        seen.add(id);
-        // Hydrate the hit into an actual source span before labeling it as
-        // code context (deep-audit Rank 1 / PR3). Metadata-only fallback
-        // preserves navigation value when the file cannot be read.
-        const searchHit: SearchHit = {
-          path: hit.path,
-          line: hit.line,
-          symbol: typeof hit.symbol === "string" && hit.symbol.length > 0 ? hit.symbol : null,
-          method: hit.method,
-        };
-        const hydratedSpan = await hydrateSearchHit(searchHit, fileReader);
-        const text = hydratedSpan?.fragmentText ?? [
-          `# Code intelligence result`,
-          `path: ${hit.path}`,
-          `line: ${hit.line}`,
-          `symbol: ${hit.symbol}`,
-          `index method: ${hit.method}`,
-          `(source span unavailable — request read for implementation)`,
-        ].join("\n");
-        const hash = computeContentHash(text);
-        const fragment: ContextFragment = {
-          id,
-          kind: "code",
-          contentRef: {
-            hash,
-            uri: `artifact://sha256/${hash.slice("sha256:".length)}` as ContextFragment["contentRef"]["uri"],
-            mediaType: "text/plain",
-            bytes: BigInt(new TextEncoder().encode(text).byteLength) as ContextFragment["contentRef"]["bytes"],
-          },
-          textContent: text,
-          source: {
-            uri: `workspace://${hit.path}`,
-            producer: "terminus-kernel-code-intel",
-            producerVersion: "v1",
-            observedAt,
-            observedBy: "kernel",
-            evidenceRefs: [],
-          },
-          sourceVersion: null,
-          authority: 55,
-          priority: 55,
-          trust: "derived",
-          confidentiality: "workspace",
-          injectionRisk: "low",
-          exactness: "recoverable_by_reference",
-          scope: {
-            workspaceId: null,
-            sessionId: sessionId as ContextFragment["scope"]["sessionId"],
-            taskId: taskId as ContextFragment["scope"]["taskId"],
-            pathPatterns: [hit.path],
-          },
-          freshness: { observedAt, sourceVersion: null, stale: false, staleReason: null },
-          dependencies: [],
-          invalidation: [{ kind: "file_changed", selector: hit.path }],
-          estimatedTokens: { [modelKey]: Math.max(1, Math.ceil(text.length / 4)) },
-          selectionFeatures: {
-            relevance: query.suggestedMethods.includes(mapRetrievalMethod(hit.method)) ? 0.9 : 0.6,
-            novelty: 0.7,
-            coverage: 0.8,
-            uncertaintyReduction: 0.7,
-            riskReduction: 0.5,
-            modelCompatibility: 1,
-            redundancyPenalty: 0,
-            injectionPenalty: 0,
-          },
-        };
-        results.push({
-          fragment,
-          method: mapRetrievalMethod(hit.method),
-          rawScore: 1,
-          rerankedScore: 1,
-          sourceVersion: hydratedSpan?.fileSha256 ?? null,
-          reason: query.reason,
-        });
-      }
-    }
-    return results;
-  };
-  return {
-    retrieve: (queries) => retrieve(queries),
-    expandForGaps: (gaps) => retrieve(gaps.map((gap) => ({
-      text: gap.requirement,
-      reason: `evidence gap: ${gap.requirementId}`,
-      suggestedMethods: ["lexical_bm25"],
-    }))),
-  };
-}
-
-function mapRetrievalMethod(method: string): RetrievalMethod {
-  switch (method) {
-    case "tree_sitter":
-    case "lsp":
-    case "graph":
-      return method === "graph" ? "dependency_graph" : method;
-    case "lexical_bm25":
-      return method;
-    default:
-      return "lexical_bm25";
-  }
-}
+// Note: kernelRetrievalPipeline and mapRetrievalMethod are extracted to
+// ./agent/retrieval-pipeline.ts with comprehensive per-turn telemetry and
+// chunked lexical retrieval candidate support.
 
 interface AgentTaskTransition {
   readonly taskId: string;
@@ -18231,17 +17981,18 @@ async function agentLoop(turnId: string): Promise<void> {
               retrieve: async () => [],
               expandForGaps: async () => [],
             }
-          : kernelRetrievalPipeline(
-              requireKernelUds(),
-              buildArtifactContext,
-              worldState.observedAt,
-              selectedModel.modelKey,
-              task.sessionId,
-              task.id,
-              workspace.id,
-              repositorySignals.repositoryMap,
-              contract.allowedScope,
-            ),
+          : kernelRetrievalPipeline({
+              clients: requireKernelUds(),
+              buildContext: buildArtifactContext,
+              observedAt: worldState.observedAt,
+              modelKey: selectedModel.modelKey,
+              sessionId: task.sessionId,
+              taskId: task.id,
+              workspaceId: workspace.id,
+              repositoryMap: repositorySignals.repositoryMap,
+              allowedScope: contract.allowedScope,
+              profileMode: harnessProfileMode,
+            }),
         signal: abortController.signal,
       });
       previousCacheEpoch = readCacheEpochSnapshot(compiled.manifest.decisionRecord)

--- a/mini-services/terminus-control/src/index.ts
+++ b/mini-services/terminus-control/src/index.ts
@@ -17945,6 +17945,20 @@ async function agentLoop(turnId: string): Promise<void> {
           (effectiveWorldState.sections as Record<string, unknown>).recent_history = priorSection.previous_turn;
         }
       }
+      const activeRetrievalPipeline = !workspaceActivated
+        ? null
+        : kernelRetrievalPipeline({
+            clients: requireKernelUds(),
+            buildContext: buildArtifactContext,
+            observedAt: worldState.observedAt,
+            modelKey: selectedModel.modelKey,
+            sessionId: task.sessionId,
+            taskId: task.id,
+            workspaceId: workspace.id,
+            repositoryMap: repositorySignals.repositoryMap,
+            allowedScope: contract.allowedScope,
+            profileMode: harnessProfileMode,
+          });
       const compiled = await compileContext({
         task: effectiveTaskSnapshot,
         thread: threadSnapshot,
@@ -17976,23 +17990,10 @@ async function agentLoop(turnId: string): Promise<void> {
         toolSchemas: activeToolSchemas,
         compactionPolicy: { enabled: false, targetTokens: Number(contextBudget.optionalContextTarget) },
         store: contextStore,
-        retrievalPipeline: !workspaceActivated
-          ? {
-              retrieve: async () => [],
-              expandForGaps: async () => [],
-            }
-          : kernelRetrievalPipeline({
-              clients: requireKernelUds(),
-              buildContext: buildArtifactContext,
-              observedAt: worldState.observedAt,
-              modelKey: selectedModel.modelKey,
-              sessionId: task.sessionId,
-              taskId: task.id,
-              workspaceId: workspace.id,
-              repositoryMap: repositorySignals.repositoryMap,
-              allowedScope: contract.allowedScope,
-              profileMode: harnessProfileMode,
-            }),
+        retrievalPipeline: activeRetrievalPipeline ?? {
+          retrieve: async () => [],
+          expandForGaps: async () => [],
+        },
         signal: abortController.signal,
       });
       previousCacheEpoch = readCacheEpochSnapshot(compiled.manifest.decisionRecord)
@@ -18039,6 +18040,7 @@ async function agentLoop(turnId: string): Promise<void> {
           model: selectedModel.modelKey,
           total_estimated_tokens: compiled.totalEstimatedTokens,
           omitted_count: compiled.omitted.length,
+          retrieval_telemetry: activeRetrievalPipeline?.telemetry.snapshot() ?? null,
         },
         artifactRefs: [requestArtifact.uri],
       }, async (tx) => {

--- a/mini-services/terminus-kernel/src/grpc.rs
+++ b/mini-services/terminus-kernel/src/grpc.rs
@@ -2205,6 +2205,8 @@ fn connector_outcome(outcome: terminus_connector::Outcome) -> &'static str {
 
 #[tonic::async_trait]
 impl CodeIntelligenceRpc for GrpcKernel {
+    /// Note: CodeSearch currently delegates to `inspect_symbol` and performs
+    /// exact symbol name lookup against the heuristic symbol index, not full-text or fuzzy search.
     async fn search(
         &self,
         request: Request<protocol::CodeSearchRequest>,

--- a/packages/aci/src/search.ts
+++ b/packages/aci/src/search.ts
@@ -15,7 +15,7 @@
  */
 import { z } from "zod";
 import type { ContentHash } from "@terminus/domain";
-import { computeContentHash } from "@terminus/context-ir";
+import { computeContentHash, calculateBm25Score } from "@terminus/context-ir";
 import type {
   ToolExecutor,
   ToolCallContext,
@@ -187,27 +187,7 @@ function symbolKindForLine(line: string): string | undefined {
 
 // ────────────────────────── Reranking & BM25 Scoring ─────────────────────────
 
-export function calculateBm25Score(query: string, text: string): number {
-  const qTerms = query.toLowerCase().split(/\s+/).filter(Boolean);
-  const textLower = text.toLowerCase();
-  let score = 0;
-
-  for (const term of qTerms) {
-    if (term.length === 0) continue;
-    let count = 0;
-    let pos = 0;
-    while ((pos = textLower.indexOf(term, pos)) !== -1) {
-      count++;
-      pos += term.length;
-    }
-    if (count > 0) {
-      // BM25 term frequency term: tf / (tf + 1.2)
-      score += (count * 2.2) / (count + 1.2);
-    }
-  }
-
-  return score;
-}
+export { calculateBm25Score } from "@terminus/context-ir";
 
 export function diversityRerank(matches: readonly SearchMatch[], limit: number): readonly SearchMatch[] {
   const result: SearchMatch[] = [];

--- a/packages/context-compiler/src/bm25.test.ts
+++ b/packages/context-compiler/src/bm25.test.ts
@@ -52,7 +52,7 @@ describe("BM25 with token-based normalization", () => {
     // Both docs contain 'target_term' once.
     // Short doc has few tokens; long doc has many tokens.
     const shortDoc = tokenizeForBm25("target_term some other context");
-    const longDoc = tokenizeForBm25("target_term " + "filler word ".repeat(50));
+    const longDoc = tokenizeForBm25(`target_term ${"filler word ".repeat(50)}`);
     const corpus = [shortDoc, longDoc];
     const df = computeDocumentFrequencies(corpus);
     const avgdl = computeAvgDocTokens(corpus);

--- a/packages/context-compiler/src/bm25.test.ts
+++ b/packages/context-compiler/src/bm25.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import {
+  calculateBm25Score,
+  computeAvgDocTokens,
+  computeDocumentFrequencies,
+  computeTermFrequencies,
+  countTokensForBm25,
+  rankDocumentsBm25,
+  scoreDocumentBm25,
+  tokenizeForBm25,
+} from "./bm25.js";
+
+describe("BM25 with token-based normalization", () => {
+  it("tokenizes text into lowercase tokens filtering single characters", () => {
+    const tokens = tokenizeForBm25("function calculateTotal_v2(price, tax, a) { return price + tax; }");
+    expect(tokens).toContain("function");
+    expect(tokens).toContain("calculatetotal_v2");
+    expect(tokens).toContain("price");
+    expect(tokens).toContain("tax");
+    expect(tokens).toContain("return");
+    expect(tokens).not.toContain("a"); // single char filtered
+  });
+
+  it("computes document length in tokens", () => {
+    const count = countTokensForBm25("hello world foo bar");
+    expect(count).toBe(4);
+  });
+
+  it("computes term and document frequencies accurately", () => {
+    const doc1 = tokenizeForBm25("error in auth handler");
+    const doc2 = tokenizeForBm25("success in auth service");
+    const doc3 = tokenizeForBm25("database connection error");
+
+    const tf1 = computeTermFrequencies(doc1);
+    expect(tf1.get("auth")).toBe(1);
+    expect(tf1.get("in")).toBe(1);
+
+    const df = computeDocumentFrequencies([doc1, doc2, doc3]);
+    expect(df.get("auth")).toBe(2);
+    expect(df.get("error")).toBe(2);
+    expect(df.get("database")).toBe(1);
+  });
+
+  it("computes average document length in tokens", () => {
+    const doc1 = tokenizeForBm25("one two three"); // 3 tokens
+    const doc2 = tokenizeForBm25("one two three four five"); // 5 tokens
+    const avg = computeAvgDocTokens([doc1, doc2]);
+    expect(avg).toBe(4);
+  });
+
+  it("penalizes document length using tokens not characters", () => {
+    // Both docs contain 'target_term' once.
+    // Short doc has few tokens; long doc has many tokens.
+    const shortDoc = tokenizeForBm25("target_term some other context");
+    const longDoc = tokenizeForBm25("target_term " + "filler word ".repeat(50));
+    const corpus = [shortDoc, longDoc];
+    const df = computeDocumentFrequencies(corpus);
+    const avgdl = computeAvgDocTokens(corpus);
+
+    const shortScore = scoreDocumentBm25({
+      queryTokens: ["target_term"],
+      docTokens: shortDoc,
+      docFrequencies: df,
+      corpusSize: 2,
+      avgDocTokens: avgdl,
+    });
+
+    const longScore = scoreDocumentBm25({
+      queryTokens: ["target_term"],
+      docTokens: longDoc,
+      docFrequencies: df,
+      corpusSize: 2,
+      avgDocTokens: avgdl,
+    });
+
+    expect(shortScore).toBeGreaterThan(longScore);
+  });
+
+  it("ranks documents by BM25 relevance", () => {
+    const docs = [
+      { id: "1", text: "database retry logic and connection pool" },
+      { id: "2", text: "user authentication with jwt tokens" },
+      { id: "3", text: "database query retry with exponential backoff" },
+    ];
+
+    const ranked = rankDocumentsBm25({
+      query: "database retry backoff",
+      documents: docs,
+      getText: (d) => d.text,
+    });
+
+    expect(ranked.length).toBeGreaterThan(0);
+    // doc 3 matches database, retry, and backoff -> should rank first
+    expect(ranked[0]!.item.id).toBe("3");
+    expect(ranked[1]!.item.id).toBe("1");
+  });
+
+  it("computes standalone single-doc score with token normalization", () => {
+    const scoreExact = calculateBm25Score("shipping threshold", "shipping threshold is 75 dollars");
+    const scorePartial = calculateBm25Score("shipping threshold", "shipping cost flat rate");
+    const scoreZero = calculateBm25Score("shipping threshold", "user password reset");
+
+    expect(scoreExact).toBeGreaterThan(scorePartial);
+    expect(scorePartial).toBeGreaterThan(scoreZero);
+    expect(scoreZero).toBe(0);
+  });
+});

--- a/packages/context-compiler/src/bm25.ts
+++ b/packages/context-compiler/src/bm25.ts
@@ -1,0 +1,5 @@
+/**
+ * Canonical BM25 scoring with token-based document length normalization.
+ * Re-exported from @terminus/context-ir.
+ */
+export * from "@terminus/context-ir";

--- a/packages/context-compiler/src/bm25.ts
+++ b/packages/context-compiler/src/bm25.ts
@@ -2,4 +2,14 @@
  * Canonical BM25 scoring with token-based document length normalization.
  * Re-exported from @terminus/context-ir.
  */
-export * from "@terminus/context-ir";
+export type { Bm25Options, Bm25ScoredItem } from "@terminus/context-ir";
+export {
+  tokenizeForBm25,
+  countTokensForBm25,
+  computeTermFrequencies,
+  computeDocumentFrequencies,
+  computeAvgDocTokens,
+  scoreDocumentBm25,
+  calculateBm25Score,
+  rankDocumentsBm25,
+} from "@terminus/context-ir";

--- a/packages/context-compiler/src/index.ts
+++ b/packages/context-compiler/src/index.ts
@@ -158,6 +158,14 @@ export type {
   RetrievalSelectionMetrics,
 } from "./retrieval-metrics.js";
 
+export * from "./bm25.js";
+import {
+  tokenizeForBm25,
+  computeDocumentFrequencies,
+  computeAvgDocTokens,
+  scoreDocumentBm25,
+} from "./bm25.js";
+
 export {
   buildHandoffBundle,
   formatHandoffBundle,
@@ -2380,7 +2388,9 @@ export class LexicalRetrieval implements RetrievalPipeline {
       content: this.index.get(p) ?? "",
       version: this.index.versions?.[p] ?? null,
     }));
-    const df = computeDocumentFrequencies(docs.map((d) => d.content));
+    const tokenizedDocs = docs.map((d) => tokenizeForBm25(d.content));
+    const df = computeDocumentFrequencies(tokenizedDocs);
+    const avgDocTokens = computeAvgDocTokens(tokenizedDocs);
     const N = Math.max(1, docs.length);
     const results: RetrievalResult[] = [];
     const seenFragmentIds = new Set<string>();
@@ -2410,27 +2420,20 @@ export class LexicalRetrieval implements RetrievalPipeline {
         }
         continue;
       }
-      // 2. Lexical BM25-style scoring.
-      const qTokens = tokenize(q.text);
+      // 2. Lexical BM25-style scoring with token-length normalization.
+      const qTokens = tokenizeForBm25(q.text);
       if (qTokens.length === 0) continue;
       const scored = docs
-        .map((d) => {
-          const tfMap = termFrequencies(d.content);
-          let score = 0;
-          for (const term of qTokens) {
-            const tf = tfMap.get(term) ?? 0;
-            if (tf === 0) continue;
-            const docFreq = df.get(term) ?? 0;
-            const idf = Math.log(1 + (N - docFreq + 0.5) / (docFreq + 0.5));
-            const k1 = 1.5;
-            const b = 0.75;
-            const dl = d.content.length;
-            const avgdl = avgDocLength(docs);
-            const denom = tf + k1 * (1 - b + b * (dl / Math.max(1, avgdl)));
-            score += idf * (tf * (k1 + 1)) / Math.max(1, denom);
-          }
-          return { doc: d, score };
-        })
+        .map((d, idx) => ({
+          doc: d,
+          score: scoreDocumentBm25({
+            queryTokens: qTokens,
+            docTokens: tokenizedDocs[idx]!,
+            docFrequencies: df,
+            corpusSize: N,
+            avgDocTokens,
+          }),
+        }))
         .filter((s) => s.score > 0)
         .sort((a, b) => b.score - a.score)
         .slice(0, 5);
@@ -2541,42 +2544,7 @@ export class LexicalRetrieval implements RetrievalPipeline {
   }
 }
 
-/** Tokenize a string for BM25 scoring. */
-function tokenize(text: string): readonly string[] {
-  return text
-    .toLowerCase()
-    .split(/[^a-z0-9_]+/)
-    .filter((t) => t.length > 1);
-}
 
-/** Compute term frequencies for a document. */
-function termFrequencies(content: string): Map<string, number> {
-  const map = new Map<string, number>();
-  for (const t of tokenize(content)) {
-    map.set(t, (map.get(t) ?? 0) + 1);
-  }
-  return map;
-}
-
-/** Compute document frequencies across a corpus. */
-function computeDocumentFrequencies(docs: readonly string[]): Map<string, number> {
-  const map = new Map<string, number>();
-  for (const d of docs) {
-    const seen = new Set<string>();
-    for (const t of tokenize(d)) {
-      if (seen.has(t)) continue;
-      seen.add(t);
-      map.set(t, (map.get(t) ?? 0) + 1);
-    }
-  }
-  return map;
-}
-
-/** Average document length (in characters) across a corpus. */
-function avgDocLength(docs: readonly { readonly content: string }[]): number {
-  if (docs.length === 0) return 1;
-  return docs.reduce((s, d) => s + d.content.length, 0) / docs.length;
-}
 
 /** Extract a snippet around the first matching token in the content. */
 function extractSnippet(content: string, queryTokens: readonly string[], windowSize: number): string {

--- a/packages/context-ir/src/bm25.ts
+++ b/packages/context-ir/src/bm25.ts
@@ -6,7 +6,7 @@
  */
 
 export interface Bm25Options {
-  /** Term frequency saturation parameter. Default is 1.5. */
+  /** Term frequency saturation parameter. Default is 1.5. Must be non-negative. */
   readonly k1?: number;
   /** Length normalization parameter in [0, 1]. Default is 0.75. */
   readonly b?: number;
@@ -15,118 +15,147 @@ export interface Bm25Options {
 const DEFAULT_K1 = 1.5;
 const DEFAULT_B = 0.75;
 
+/** Resolve and validate BM25 parameters against finite documented ranges. */
+export const resolveBm25Params = (options?: Bm25Options): { readonly k1: number; readonly b: number } => {
+  const k1 = typeof options?.k1 === "number" && Number.isFinite(options.k1) && options.k1 >= 0
+    ? options.k1
+    : DEFAULT_K1;
+  const b = typeof options?.b === "number" && Number.isFinite(options.b) && options.b >= 0 && options.b <= 1
+    ? options.b
+    : DEFAULT_B;
+  return { k1, b };
+};
+
 /** Tokenize a string into alphanumeric terms for lexical BM25 matching. */
-export function tokenizeForBm25(text: string): readonly string[] {
-  return text
+export const tokenizeForBm25 = (text: string): readonly string[] =>
+  text
     .toLowerCase()
     .split(/[^a-z0-9_]+/)
     .filter((token) => token.length > 1);
-}
 
 /** Compute the document length in tokens. */
-export function countTokensForBm25(text: string): number {
-  return Math.max(1, tokenizeForBm25(text).length);
-}
+export const countTokensForBm25 = (text: string): number =>
+  Math.max(1, tokenizeForBm25(text).length);
 
 /** Compute term frequencies for a single document. */
-export function computeTermFrequencies(tokens: readonly string[]): Map<string, number> {
-  const map = new Map<string, number>();
+export const computeTermFrequencies = (tokens: readonly string[]): Map<string, number> => {
+  const frequencyMap = new Map<string, number>();
   for (const token of tokens) {
-    map.set(token, (map.get(token) ?? 0) + 1);
+    frequencyMap.set(token, (frequencyMap.get(token) ?? 0) + 1);
   }
-  return map;
-}
+  return frequencyMap;
+};
 
 /** Compute document frequencies across a corpus of documents. */
-export function computeDocumentFrequencies(
+export const computeDocumentFrequencies = (
   tokenizedDocs: ReadonlyArray<readonly string[]>,
-): Map<string, number> {
-  const map = new Map<string, number>();
+): Map<string, number> => {
+  const frequencyMap = new Map<string, number>();
   for (const tokens of tokenizedDocs) {
     const seen = new Set<string>();
     for (const token of tokens) {
       if (seen.has(token)) continue;
       seen.add(token);
-      map.set(token, (map.get(token) ?? 0) + 1);
+      frequencyMap.set(token, (frequencyMap.get(token) ?? 0) + 1);
     }
   }
-  return map;
-}
+  return frequencyMap;
+};
 
 /** Compute average document length in tokens across tokenized documents. */
-export function computeAvgDocTokens(tokenizedDocs: ReadonlyArray<readonly string[]>): number {
+export const computeAvgDocTokens = (tokenizedDocs: ReadonlyArray<readonly string[]>): number => {
   if (tokenizedDocs.length === 0) return 1;
   const totalTokens = tokenizedDocs.reduce((sum, doc) => sum + doc.length, 0);
   return Math.max(1, totalTokens / tokenizedDocs.length);
-}
+};
+
+/** Score a single term using Robertson-Spärck Jones IDF and BM25 term weighting. */
+const scoreBm25Term = (
+  termFrequency: number,
+  docFrequency: number,
+  corpusCount: number,
+  docTokensCount: number,
+  avgDocTokensCount: number,
+  k1: number,
+  b: number,
+): number => {
+  const idf = Math.log(1 + (corpusCount - docFrequency + 0.5) / (docFrequency + 0.5));
+  const denominator = termFrequency + k1 * (1 - b + b * (docTokensCount / avgDocTokensCount));
+  return idf * ((termFrequency * (k1 + 1)) / Math.max(1e-6, denominator));
+};
 
 /**
  * Score a single document against query tokens using BM25 with token length normalization.
+ * Query tokens are deduplicated so duplicate words do not artificially inflate ranking.
  */
-export function scoreDocumentBm25(input: {
+export const scoreDocumentBm25 = (input: {
   readonly queryTokens: readonly string[];
   readonly docTokens: readonly string[];
   readonly docFrequencies: ReadonlyMap<string, number>;
   readonly corpusSize: number;
   readonly avgDocTokens: number;
   readonly options?: Bm25Options | undefined;
-}): number {
+}): number => {
   const { queryTokens, docTokens, docFrequencies, corpusSize, avgDocTokens, options } = input;
   if (queryTokens.length === 0 || docTokens.length === 0 || corpusSize <= 0) return 0;
 
-  const k1 = options?.k1 ?? DEFAULT_K1;
-  const b = options?.b ?? DEFAULT_B;
-  const N = Math.max(1, corpusSize);
-  const dl = Math.max(1, docTokens.length);
-  const avgdl = Math.max(1, avgDocTokens);
+  const { k1, b } = resolveBm25Params(options);
+  const corpusCount = Math.max(1, corpusSize);
+  const docTokensCount = Math.max(1, docTokens.length);
+  const avgDocTokensCount = Math.max(1, avgDocTokens);
   const tfMap = computeTermFrequencies(docTokens);
+  const uniqueQueryTerms = new Set(queryTokens);
 
   let totalScore = 0;
-  for (const term of queryTokens) {
-    const tf = tfMap.get(term) ?? 0;
-    if (tf === 0) continue;
-    const df = docFrequencies.get(term) ?? 0;
-    // Standard Robertson-Spärck Jones IDF
-    const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
-    const denom = tf + k1 * (1 - b + b * (dl / avgdl));
-    totalScore += idf * ((tf * (k1 + 1)) / Math.max(1e-6, denom));
+  for (const term of uniqueQueryTerms) {
+    const termFrequency = tfMap.get(term) ?? 0;
+    if (termFrequency === 0) continue;
+    const docFrequency = docFrequencies.get(term) ?? 0;
+    totalScore += scoreBm25Term(
+      termFrequency,
+      docFrequency,
+      corpusCount,
+      docTokensCount,
+      avgDocTokensCount,
+      k1,
+      b,
+    );
   }
 
   return Math.max(0, totalScore);
-}
+};
 
 /**
  * Standalone BM25 scoring for an isolated (query, text) pair.
  * Used by ACI search and single-document ranking where full-corpus DF is absent.
- * Uses token-based length normalization.
+ * Uses token-based length normalization and deduplicated query terms.
  */
-export function calculateBm25Score(
+export const calculateBm25Score = (
   query: string,
   text: string,
   options?: Bm25Options,
-): number {
+): number => {
   const qTokens = tokenizeForBm25(query);
   const dTokens = tokenizeForBm25(text);
   if (qTokens.length === 0 || dTokens.length === 0) return 0;
 
-  const k1 = options?.k1 ?? DEFAULT_K1;
-  const b = options?.b ?? DEFAULT_B;
-  const dl = Math.max(1, dTokens.length);
+  const { k1, b } = resolveBm25Params(options);
+  const docTokensCount = Math.max(1, dTokens.length);
   // Default expected line/snippet length baseline: 40 tokens
-  const avgdl = 40;
+  const avgDocTokensCount = 40;
   const tfMap = computeTermFrequencies(dTokens);
+  const uniqueQueryTerms = new Set(qTokens);
 
   let score = 0;
-  for (const term of qTokens) {
-    const tf = tfMap.get(term) ?? 0;
-    if (tf === 0) continue;
-    // Token-normalized term-frequency contribution
-    const denom = tf + k1 * (1 - b + b * (dl / avgdl));
-    score += (tf * (k1 + 1)) / Math.max(1e-6, denom);
+  for (const term of uniqueQueryTerms) {
+    const termFrequency = tfMap.get(term) ?? 0;
+    if (termFrequency === 0) continue;
+    const denominator = termFrequency + k1 * (1 - b + b * (docTokensCount / avgDocTokensCount));
+    score += (termFrequency * (k1 + 1)) / Math.max(1e-6, denominator);
   }
 
   return score;
-}
+};
 
 export interface Bm25ScoredItem<T> {
   readonly item: T;
@@ -137,19 +166,19 @@ export interface Bm25ScoredItem<T> {
 /**
  * Rank a list of documents against a query string using token-normalized BM25.
  */
-export function rankDocumentsBm25<T>(input: {
+export const rankDocumentsBm25 = <T>(input: {
   readonly query: string;
   readonly documents: readonly T[];
   readonly getText: (doc: T) => string;
   readonly limit?: number;
   readonly options?: Bm25Options;
-}): readonly Bm25ScoredItem<T>[] {
+}): readonly Bm25ScoredItem<T>[] => {
   const { query, documents, getText, limit, options } = input;
   const queryTokens = tokenizeForBm25(query);
   if (queryTokens.length === 0 || documents.length === 0) return [];
 
   const tokenizedDocs = documents.map((doc) => tokenizeForBm25(getText(doc)));
-  const df = computeDocumentFrequencies(tokenizedDocs);
+  const docFrequencies = computeDocumentFrequencies(tokenizedDocs);
   const avgDocLength = computeAvgDocTokens(tokenizedDocs);
   const corpusSize = documents.length;
 
@@ -160,7 +189,7 @@ export function rankDocumentsBm25<T>(input: {
     const score = scoreDocumentBm25({
       queryTokens,
       docTokens,
-      docFrequencies: df,
+      docFrequencies,
       corpusSize,
       avgDocTokens: avgDocLength,
       options,
@@ -172,4 +201,4 @@ export function rankDocumentsBm25<T>(input: {
 
   scored.sort((a, b) => b.score - a.score);
   return limit !== undefined && limit > 0 ? scored.slice(0, limit) : scored;
-}
+};

--- a/packages/context-ir/src/bm25.ts
+++ b/packages/context-ir/src/bm25.ts
@@ -1,0 +1,175 @@
+/**
+ * Canonical BM25 scoring with token-based document length normalization.
+ *
+ * Implements Okapi BM25 ranking (SPEC §8.4, §34.6) where document lengths (dl)
+ * and average document lengths (avgdl) are computed in TOKENS, not characters.
+ */
+
+export interface Bm25Options {
+  /** Term frequency saturation parameter. Default is 1.5. */
+  readonly k1?: number;
+  /** Length normalization parameter in [0, 1]. Default is 0.75. */
+  readonly b?: number;
+}
+
+const DEFAULT_K1 = 1.5;
+const DEFAULT_B = 0.75;
+
+/** Tokenize a string into alphanumeric terms for lexical BM25 matching. */
+export function tokenizeForBm25(text: string): readonly string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/)
+    .filter((token) => token.length > 1);
+}
+
+/** Compute the document length in tokens. */
+export function countTokensForBm25(text: string): number {
+  return Math.max(1, tokenizeForBm25(text).length);
+}
+
+/** Compute term frequencies for a single document. */
+export function computeTermFrequencies(tokens: readonly string[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const token of tokens) {
+    map.set(token, (map.get(token) ?? 0) + 1);
+  }
+  return map;
+}
+
+/** Compute document frequencies across a corpus of documents. */
+export function computeDocumentFrequencies(
+  tokenizedDocs: ReadonlyArray<readonly string[]>,
+): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const tokens of tokenizedDocs) {
+    const seen = new Set<string>();
+    for (const token of tokens) {
+      if (seen.has(token)) continue;
+      seen.add(token);
+      map.set(token, (map.get(token) ?? 0) + 1);
+    }
+  }
+  return map;
+}
+
+/** Compute average document length in tokens across tokenized documents. */
+export function computeAvgDocTokens(tokenizedDocs: ReadonlyArray<readonly string[]>): number {
+  if (tokenizedDocs.length === 0) return 1;
+  const totalTokens = tokenizedDocs.reduce((sum, doc) => sum + doc.length, 0);
+  return Math.max(1, totalTokens / tokenizedDocs.length);
+}
+
+/**
+ * Score a single document against query tokens using BM25 with token length normalization.
+ */
+export function scoreDocumentBm25(input: {
+  readonly queryTokens: readonly string[];
+  readonly docTokens: readonly string[];
+  readonly docFrequencies: ReadonlyMap<string, number>;
+  readonly corpusSize: number;
+  readonly avgDocTokens: number;
+  readonly options?: Bm25Options | undefined;
+}): number {
+  const { queryTokens, docTokens, docFrequencies, corpusSize, avgDocTokens, options } = input;
+  if (queryTokens.length === 0 || docTokens.length === 0 || corpusSize <= 0) return 0;
+
+  const k1 = options?.k1 ?? DEFAULT_K1;
+  const b = options?.b ?? DEFAULT_B;
+  const N = Math.max(1, corpusSize);
+  const dl = Math.max(1, docTokens.length);
+  const avgdl = Math.max(1, avgDocTokens);
+  const tfMap = computeTermFrequencies(docTokens);
+
+  let totalScore = 0;
+  for (const term of queryTokens) {
+    const tf = tfMap.get(term) ?? 0;
+    if (tf === 0) continue;
+    const df = docFrequencies.get(term) ?? 0;
+    // Standard Robertson-Spärck Jones IDF
+    const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
+    const denom = tf + k1 * (1 - b + b * (dl / avgdl));
+    totalScore += idf * ((tf * (k1 + 1)) / Math.max(1e-6, denom));
+  }
+
+  return Math.max(0, totalScore);
+}
+
+/**
+ * Standalone BM25 scoring for an isolated (query, text) pair.
+ * Used by ACI search and single-document ranking where full-corpus DF is absent.
+ * Uses token-based length normalization.
+ */
+export function calculateBm25Score(
+  query: string,
+  text: string,
+  options?: Bm25Options,
+): number {
+  const qTokens = tokenizeForBm25(query);
+  const dTokens = tokenizeForBm25(text);
+  if (qTokens.length === 0 || dTokens.length === 0) return 0;
+
+  const k1 = options?.k1 ?? DEFAULT_K1;
+  const b = options?.b ?? DEFAULT_B;
+  const dl = Math.max(1, dTokens.length);
+  // Default expected line/snippet length baseline: 40 tokens
+  const avgdl = 40;
+  const tfMap = computeTermFrequencies(dTokens);
+
+  let score = 0;
+  for (const term of qTokens) {
+    const tf = tfMap.get(term) ?? 0;
+    if (tf === 0) continue;
+    // Token-normalized term-frequency contribution
+    const denom = tf + k1 * (1 - b + b * (dl / avgdl));
+    score += (tf * (k1 + 1)) / Math.max(1e-6, denom);
+  }
+
+  return score;
+}
+
+export interface Bm25ScoredItem<T> {
+  readonly item: T;
+  readonly score: number;
+  readonly docTokens: readonly string[];
+}
+
+/**
+ * Rank a list of documents against a query string using token-normalized BM25.
+ */
+export function rankDocumentsBm25<T>(input: {
+  readonly query: string;
+  readonly documents: readonly T[];
+  readonly getText: (doc: T) => string;
+  readonly limit?: number;
+  readonly options?: Bm25Options;
+}): readonly Bm25ScoredItem<T>[] {
+  const { query, documents, getText, limit, options } = input;
+  const queryTokens = tokenizeForBm25(query);
+  if (queryTokens.length === 0 || documents.length === 0) return [];
+
+  const tokenizedDocs = documents.map((doc) => tokenizeForBm25(getText(doc)));
+  const df = computeDocumentFrequencies(tokenizedDocs);
+  const avgDocLength = computeAvgDocTokens(tokenizedDocs);
+  const corpusSize = documents.length;
+
+  const scored: Bm25ScoredItem<T>[] = [];
+  for (let i = 0; i < documents.length; i++) {
+    const doc = documents[i]!;
+    const docTokens = tokenizedDocs[i]!;
+    const score = scoreDocumentBm25({
+      queryTokens,
+      docTokens,
+      docFrequencies: df,
+      corpusSize,
+      avgDocTokens: avgDocLength,
+      options,
+    });
+    if (score > 0) {
+      scored.push({ item: doc, score, docTokens });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return limit !== undefined && limit > 0 ? scored.slice(0, limit) : scored;
+}

--- a/packages/context-ir/src/index.ts
+++ b/packages/context-ir/src/index.ts
@@ -442,3 +442,6 @@ function sortJson(value: unknown): unknown {
   }
   return value;
 }
+
+export * from "./bm25.js";
+

--- a/packages/terminus-kernel-client/src/generated-ts-proto/terminus/kernel/v1/kernel.ts
+++ b/packages/terminus-kernel-client/src/generated-ts-proto/terminus/kernel/v1/kernel.ts
@@ -925,6 +925,11 @@ export interface ConnectorChunk {
   receipt?: ConnectorReceiptMessage | undefined;
 }
 
+/**
+ * CodeSearchRequest performs code intelligence search.
+ * Currently delegates to inspect_symbol and performs exact symbol lookup
+ * against the heuristic symbol index.
+ */
 export interface CodeSearchRequest {
   context: RequestContext | undefined;
   workspaceId: string;

--- a/packages/terminus-kernel-client/src/generated/terminus/kernel/v1/kernel_pb.d.ts
+++ b/packages/terminus-kernel-client/src/generated/terminus/kernel/v1/kernel_pb.d.ts
@@ -3168,6 +3168,10 @@ export declare type ConnectorChunk = Message<"terminus.kernel.v1.ConnectorChunk"
 export declare const ConnectorChunkSchema: GenMessage<ConnectorChunk>;
 
 /**
+ * CodeSearchRequest performs code intelligence search.
+ * Currently delegates to inspect_symbol and performs exact symbol lookup
+ * against the heuristic symbol index.
+ *
  * @generated from message terminus.kernel.v1.CodeSearchRequest
  */
 export declare type CodeSearchRequest = Message<"terminus.kernel.v1.CodeSearchRequest"> & {

--- a/prompts/authority/safety-rules.md
+++ b/prompts/authority/safety-rules.md
@@ -1,5 +1,11 @@
 # Safety Rules
 
+> [!WARNING]
+> **DEAD PROMPT FILE (HISTORICAL / INACTIVE)**:
+> This file is not loaded by the live compiler or runtime path.
+> The shipped safety rules are defined in TypeScript constants in
+> `mini-services/terminus-control/src/agent/system-prompt.ts`.
+
 These rules are non-negotiable. They override every other instruction source
 except the platform authority system prompt. They apply to every agent,
 every turn, every delegation, and every external harness.

--- a/prompts/authority/system.md
+++ b/prompts/authority/system.md
@@ -1,5 +1,11 @@
 # Terminus Platform Authority
 
+> [!WARNING]
+> **DEAD PROMPT FILE (HISTORICAL / INACTIVE)**:
+> This file is not loaded by the live compiler or runtime path.
+> The shipped system prompt is defined in TypeScript constants in
+> `mini-services/terminus-control/src/agent/system-prompt.ts`.
+
 You are operating inside **Terminus**, a provider-neutral coding-agent operating
 system. You are not a generic assistant. You are a task-owned agent whose
 every effect is mediated by the Terminus kernel.

--- a/proto/terminus/kernel/v1/kernel.proto
+++ b/proto/terminus/kernel/v1/kernel.proto
@@ -917,6 +917,9 @@ message ConnectorChunk {
 // Code intelligence service (SPEC §11.8, §31.1)
 // =============================================================================
 
+// CodeSearchRequest performs code intelligence search.
+// Currently delegates to inspect_symbol and performs exact symbol lookup
+// against the heuristic symbol index.
 message CodeSearchRequest {
   RequestContext context = 1;
   string workspace_id = 2;

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/README.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/README.md
@@ -1,0 +1,5 @@
+# retrieval-cross-file-01
+
+Archetype: Cross-file task requiring references or dependencies.
+The agent must update `src/client.py` and trace references across the codebase to update call sites in `src/api.py`, `src/cli.py`, and `src/scheduler.py`.
+Hidden tests verify negative retry count validation, scheduler batch retry configurations, and integration across modules.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/environment.lock
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/environment.lock
@@ -1,0 +1,2 @@
+python=3.12
+pytest=8.2.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/expected-properties.yaml
@@ -1,0 +1,11 @@
+properties:
+  - id: P-RETRIEVAL-CROSS-FILE-01-PASS
+    description: "All client, API, CLI, and scheduler tests pass including hidden integration checks."
+    target_metric: "resolved"
+    direction: "maximize"
+    threshold: 1.0
+  - id: P-RETRIEVAL-CROSS-FILE-01-SCOPE
+    description: "Only src/client.py, src/api.py, src/cli.py, and src/scheduler.py are modified."
+    target_metric: "scope_retained"
+    direction: "maximize"
+    threshold: 1.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/expected-properties.yaml
@@ -1,11 +1,18 @@
-properties:
-  - id: P-RETRIEVAL-CROSS-FILE-01-PASS
-    description: "All client, API, CLI, and scheduler tests pass including hidden integration checks."
-    target_metric: "resolved"
-    direction: "maximize"
-    threshold: 1.0
-  - id: P-RETRIEVAL-CROSS-FILE-01-SCOPE
-    description: "Only src/client.py, src/api.py, src/cli.py, and src/scheduler.py are modified."
-    target_metric: "scope_retained"
-    direction: "maximize"
-    threshold: 1.0
+expected:
+  outcome: completed
+  changed_files:
+    - src/client.py
+    - src/api.py
+    - src/cli.py
+    - src/scheduler.py
+  tests:
+    - command: python -m pytest -q tests
+      status: passed
+    - command: python -m pytest -q hidden/test_hidden.py
+      status: passed
+  cost_usd_max: 0.15
+  turns_max: 6
+  rejection_triggers:
+    - changed_files outside [src/client.py, src/api.py, src/cli.py, src/scheduler.py]
+    - client retry propagation defect still present
+    - public test regression

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/grader/run.py
@@ -1,0 +1,82 @@
+"""Deterministic grader for retrieval-v1/retrieval-cross-file-01.
+
+Verifies:
+1. Full test suite (public + hidden integration tests) passes (returncode == 0)
+2. Scope: all 4 files (src/client.py, src/api.py, src/cli.py, src/scheduler.py) updated cleanly
+Does not check for "PASS" in stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(workdir: Path, *args: str) -> tuple[bool, str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    output = (result.stdout + result.stderr).strip()
+    return result.returncode == 0, output[-1_000:]
+
+
+def _changed_files(workdir: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    return {
+        line[3:].strip()
+        for line in result.stdout.splitlines()
+        if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
+    }
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    workdir = Path(payload["workdir"]).resolve()
+    checks: list[tuple[str, bool, str]] = []
+
+    # 1. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
+
+    # 2. Run hidden tests if present
+    hidden_test = workdir / "hidden" / "test_hidden.py"
+    if hidden_test.exists():
+        hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
+        checks.append(("hidden cross-file tests pass", hidden_ok, hidden_out))
+    else:
+        checks.append(("hidden cross-file tests pass", False, "hidden test file missing"))
+
+    # 3. Scope verification: all 4 files changed and no outside modifications
+    changed = _changed_files(workdir)
+    expected = {"src/client.py", "src/api.py", "src/cli.py", "src/scheduler.py"}
+    scope_ok = changed == expected
+    checks.append(("cross-file scope (client, api, cli, scheduler)", scope_ok, str(sorted(changed))))
+
+    passed = sum(ok for _, ok, _ in checks)
+    all_passed = passed == len(checks)
+    result = {
+        "passed": all_passed,
+        "score": passed / len(checks),
+        "evidence": [f"{name}: {'OK' if ok else 'FAIL'} {detail}" for name, ok, detail in checks],
+        "metadata": {"checks_total": len(checks), "checks_passed": passed},
+    }
+    print(json.dumps(result))
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/grader/run.py
@@ -1,14 +1,16 @@
 """Deterministic grader for retrieval-v1/retrieval-cross-file-01.
 
 Verifies:
-1. Full test suite (public + hidden integration tests) passes (returncode == 0)
-2. Scope: all 4 files (src/client.py, src/api.py, src/cli.py, src/scheduler.py) updated cleanly
+1. Hidden cross-file tests pass (run first to prevent tampering)
+2. Public tests pass (returncode == 0)
+3. Scope: all 4 files (src/client.py, src/api.py, src/cli.py, src/scheduler.py) updated cleanly
 Does not check for "PASS" in stdout.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -20,7 +22,7 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
         cwd=workdir,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=60,
         check=False,
     )
     output = (result.stdout + result.stderr).strip()
@@ -28,19 +30,50 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
 
 
 def _changed_files(workdir: Path) -> set[str]:
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
+    git_bin = shutil.which("git") or "git"
+    # Check working tree (uncommitted/staged)
+    status_proc = subprocess.run(
+        [git_bin, "status", "--porcelain"],
         cwd=workdir,
         capture_output=True,
         text=True,
         timeout=20,
         check=False,
     )
-    return {
+    status_files = {
         line[3:].strip()
-        for line in result.stdout.splitlines()
+        for line in status_proc.stdout.splitlines()
         if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
     }
+
+    # Check committed changes against initial/base commit
+    log_proc = subprocess.run(
+        [git_bin, "log", "--reverse", "--format=%H"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    commits = [line.strip() for line in log_proc.stdout.splitlines() if line.strip()]
+    diff_files: set[str] = set()
+    if commits:
+        base_commit = commits[0]
+        diff_proc = subprocess.run(
+            [git_bin, "diff", "--name-only", base_commit, "HEAD"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        diff_files = {
+            line.strip()
+            for line in diff_proc.stdout.splitlines()
+            if line.strip() and not line.strip().startswith("hidden/")
+        }
+
+    return status_files | diff_files
 
 
 def main() -> int:
@@ -48,17 +81,17 @@ def main() -> int:
     workdir = Path(payload["workdir"]).resolve()
     checks: list[tuple[str, bool, str]] = []
 
-    # 1. Run public tests
-    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
-    checks.append(("public tests pass", pub_ok, pub_out))
-
-    # 2. Run hidden tests if present
+    # 1. Run hidden tests first to prevent candidate code tampering
     hidden_test = workdir / "hidden" / "test_hidden.py"
     if hidden_test.exists():
         hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
         checks.append(("hidden cross-file tests pass", hidden_ok, hidden_out))
     else:
         checks.append(("hidden cross-file tests pass", False, "hidden test file missing"))
+
+    # 2. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
 
     # 3. Scope verification: all 4 files changed and no outside modifications
     changed = _changed_files(workdir)

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/hidden/test_hidden.py
@@ -1,0 +1,25 @@
+"""Hidden integration tests for ApiClient retry propagation."""
+import pytest
+from src.api import fetch_user
+from src.client import ApiClient
+from src.scheduler import dispatch_batch_job
+
+
+def test_client_rejects_negative_retries():
+    client = ApiClient()
+    with pytest.raises(ValueError, match="retry_count must be non-negative"):
+        client.request("/test", retry_count=-1)
+
+
+def test_scheduler_passes_five_retries():
+    client = ApiClient()
+    res = dispatch_batch_job(client)
+    assert res["retries_allowed"] == 5
+    assert res["endpoint"] == "/jobs/batch"
+
+
+def test_custom_api_retries():
+    client = ApiClient()
+    res = fetch_user(client, "usr_99", retries=4)
+    assert res["retries_allowed"] == 4
+    assert res["endpoint"] == "/users/usr_99"

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/hidden/test_hidden.py
@@ -1,6 +1,7 @@
 """Hidden integration tests for ApiClient retry propagation."""
 import pytest
 from src.api import fetch_user
+from src.cli import run_sync
 from src.client import ApiClient
 from src.scheduler import dispatch_batch_job
 
@@ -14,12 +15,19 @@ def test_client_rejects_negative_retries():
 def test_scheduler_passes_five_retries():
     client = ApiClient()
     res = dispatch_batch_job(client)
-    assert res["retries_allowed"] == 5
-    assert res["endpoint"] == "/jobs/batch"
+    if res["retries_allowed"] != 5 or res["endpoint"] != "/jobs/batch":
+        raise AssertionError(f"scheduler retry mismatch: {res}")
 
 
 def test_custom_api_retries():
     client = ApiClient()
     res = fetch_user(client, "usr_99", retries=4)
-    assert res["retries_allowed"] == 4
-    assert res["endpoint"] == "/users/usr_99"
+    if res["retries_allowed"] != 4 or res["endpoint"] != "/users/usr_99":
+        raise AssertionError(f"api retry mismatch: {res}")
+
+
+def test_cli_sync_retries():
+    client = ApiClient()
+    res = run_sync(client, retries=7)
+    if res["retries_allowed"] != 7 or res["endpoint"] != "/sync/now":
+        raise AssertionError(f"cli sync retry mismatch: {res}")

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/policy.yaml
@@ -7,7 +7,9 @@ allowed_commands:
 allowed_read_paths:
   - "**"
 allowed_write_paths:
-  - "src/**"
-  - "tests/**"
+  - "src/client.py"
+  - "src/api.py"
+  - "src/cli.py"
+  - "src/scheduler.py"
 network: none
 max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/policy.yaml
@@ -1,0 +1,13 @@
+profile: default
+allowed_commands:
+  - "python"
+  - "python3"
+  - "pytest"
+  - "git"
+allowed_read_paths:
+  - "**"
+allowed_write_paths:
+  - "src/**"
+  - "tests/**"
+network: none
+max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/prompt.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/prompt.md
@@ -13,3 +13,4 @@ In `src/client.py`:
 
 3. Ensure all call sites and the client are updated consistently.
 4. Verify all tests pass with `python -m pytest -q`.
+5. Only modify `src/client.py`, `src/api.py`, `src/cli.py`, and `src/scheduler.py`. Do not modify tests or other files.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/prompt.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/prompt.md
@@ -1,0 +1,15 @@
+We are adding configurable retry support to our internal HTTP client.
+
+In `src/client.py`:
+1. Update `ApiClient.request(self, endpoint: str, method: str = "GET", retry_count: int = 3) -> dict`:
+   - Accept an optional `retry_count: int = 3` parameter.
+   - If `retry_count < 0`, raise `ValueError("retry_count must be non-negative")`.
+   - Record `retry_count` in the returned response dictionary under the key `"retries_allowed"`.
+
+2. Propagate this update to all callers across the repository:
+   - In `src/api.py`: update `fetch_user(client: ApiClient, user_id: str, retries: int = 2)` to pass `retry_count=retries`.
+   - In `src/cli.py`: update `run_sync(client: ApiClient, retries: int = 1)` to pass `retry_count=retries`.
+   - In `src/scheduler.py`: update `dispatch_batch_job(client: ApiClient)` to pass `retry_count=5`.
+
+3. Ensure all call sites and the client are updated consistently.
+4. Verify all tests pass with `python -m pytest -q`.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/setup.sh
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/setup.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p src tests hidden
+cat > .gitignore <<'EOF'
+__pycache__/
+.pytest_cache/
+EOF
+
+touch src/__init__.py
+
+cat > src/client.py <<'PY'
+"""Internal HTTP API Client."""
+
+from typing import Dict, Any
+
+
+class ApiClient:
+    def __init__(self, base_url: str = "https://api.internal.local"):
+        self.base_url = base_url
+
+    def request(self, endpoint: str, method: str = "GET") -> Dict[str, Any]:
+        """Perform request. Needs retry_count: int = 3 support."""
+        return {
+            "status": 200,
+            "endpoint": endpoint,
+            "method": method,
+        }
+PY
+
+cat > src/api.py <<'PY'
+"""API endpoints integration."""
+
+from src.client import ApiClient
+
+
+def fetch_user(client: ApiClient, user_id: str):
+    return client.request(f"/users/{user_id}", method="GET")
+PY
+
+cat > src/cli.py <<'PY'
+"""CLI operations."""
+
+from src.client import ApiClient
+
+
+def run_sync(client: ApiClient):
+    return client.request("/sync/now", method="POST")
+PY
+
+cat > src/scheduler.py <<'PY'
+"""Batch scheduler routines."""
+
+from src.client import ApiClient
+
+
+def dispatch_batch_job(client: ApiClient):
+    return client.request("/jobs/batch", method="POST")
+PY
+
+cat > tests/test_client.py <<'PY'
+from src.client import ApiClient
+from src.api import fetch_user
+from src.cli import run_sync
+from src.scheduler import dispatch_batch_job
+
+
+def test_basic_request():
+    client = ApiClient()
+    res = client.request("/health")
+    assert res["status"] == 200
+PY
+
+cat > justfile <<'JUST'
+test:
+    python3 -m pytest -q
+JUST
+
+if [ -f "$TERMINUS_TASK_DIR/hidden/test_hidden.py" ]; then
+  cp "$TERMINUS_TASK_DIR/hidden/test_hidden.py" hidden/test_hidden.py
+fi

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/task.yaml
@@ -27,5 +27,5 @@ acceptance_criteria:
 grader:
   entrypoint: grader/run.py
   protocol: json_stdio
-  timeout_seconds: 30
+  timeout_seconds: 60
 risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-cross-file-01/task.yaml
@@ -1,0 +1,31 @@
+suite: retrieval-v1
+task: retrieval-cross-file-01
+cohort: retrieval-v1
+title: Cross-file feature — ApiClient retry parameter propagation across call sites
+source_commit: fixture-retrieval-cross-file-01-v1
+image_digest: local:python-3.12-pytest-8
+timeout: 600
+budget:
+  max_cost_usd: 1.0
+  max_wall_seconds: 600
+  max_tool_calls: 50
+  max_turns: 20
+allowed_network: []
+secrets: {}
+grader_version: 1.0.0
+rationale: >
+  Retrieval archetype 3: Cross-file task requiring references or dependencies.
+  Updating ApiClient.request in src/client.py requires finding and updating all call sites
+  across src/api.py, src/cli.py, and src/scheduler.py.
+acceptance_criteria:
+  - id: tests-pass
+    statement: the full test suite passes including hidden cross-file integration checks
+    verification_hint: "command: python -m pytest -q"
+  - id: scope
+    statement: src/client.py and caller files were updated consistently
+    verification_hint: "command: git status --porcelain"
+grader:
+  entrypoint: grader/run.py
+  protocol: json_stdio
+  timeout_seconds: 30
+risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/README.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/README.md
@@ -1,0 +1,5 @@
+# retrieval-named-01
+
+Archetype: Named file bug fix.
+The prompt mentions `src/shipping.py` by name. The agent must update the free shipping threshold check from `> 5000` to `>= 7500`.
+Hidden tests verify threshold boundary values (5000, 7499, 7500, 7501).

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/environment.lock
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/environment.lock
@@ -1,0 +1,2 @@
+python=3.12
+pytest=8.2.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/expected-properties.yaml
@@ -1,11 +1,15 @@
-properties:
-  - id: P-RETRIEVAL-NAMED-01-PASS
-    description: "The pytest suite passes completely, including hidden boundary checks."
-    target_metric: "resolved"
-    direction: "maximize"
-    threshold: 1.0
-  - id: P-RETRIEVAL-NAMED-01-SCOPE
-    description: "Only src/shipping.py is modified by the agent."
-    target_metric: "scope_retained"
-    direction: "maximize"
-    threshold: 1.0
+expected:
+  outcome: completed
+  changed_files:
+    - src/shipping.py
+  tests:
+    - command: python -m pytest -q tests
+      status: passed
+    - command: python -m pytest -q hidden/test_hidden.py
+      status: passed
+  cost_usd_max: 0.10
+  turns_max: 5
+  rejection_triggers:
+    - changed_files outside [src/shipping.py]
+    - shipping threshold bug still present
+    - public test regression

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/expected-properties.yaml
@@ -1,0 +1,11 @@
+properties:
+  - id: P-RETRIEVAL-NAMED-01-PASS
+    description: "The pytest suite passes completely, including hidden boundary checks."
+    target_metric: "resolved"
+    direction: "maximize"
+    threshold: 1.0
+  - id: P-RETRIEVAL-NAMED-01-SCOPE
+    description: "Only src/shipping.py is modified by the agent."
+    target_metric: "scope_retained"
+    direction: "maximize"
+    threshold: 1.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/grader/run.py
@@ -1,15 +1,16 @@
 """Deterministic grader for retrieval-v1/retrieval-named-01.
 
 Verifies:
-1. Public tests pass (returncode == 0)
-2. Hidden boundary tests pass (returncode == 0)
-3. Only src/shipping.py changed (git status --porcelain)
+1. Hidden boundary tests pass (run first to prevent tampering)
+2. Public tests pass (returncode == 0)
+3. Only src/shipping.py changed (checks git status and commit diff)
 Does not check for "PASS" in stdout.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -21,7 +22,7 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
         cwd=workdir,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=60,
         check=False,
     )
     output = (result.stdout + result.stderr).strip()
@@ -29,19 +30,50 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
 
 
 def _changed_files(workdir: Path) -> set[str]:
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
+    git_bin = shutil.which("git") or "git"
+    # Check working tree (uncommitted/staged)
+    status_proc = subprocess.run(
+        [git_bin, "status", "--porcelain"],
         cwd=workdir,
         capture_output=True,
         text=True,
         timeout=20,
         check=False,
     )
-    return {
+    status_files = {
         line[3:].strip()
-        for line in result.stdout.splitlines()
+        for line in status_proc.stdout.splitlines()
         if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
     }
+
+    # Check committed changes against initial/base commit
+    log_proc = subprocess.run(
+        [git_bin, "log", "--reverse", "--format=%H"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    commits = [line.strip() for line in log_proc.stdout.splitlines() if line.strip()]
+    diff_files: set[str] = set()
+    if commits:
+        base_commit = commits[0]
+        diff_proc = subprocess.run(
+            [git_bin, "diff", "--name-only", base_commit, "HEAD"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        diff_files = {
+            line.strip()
+            for line in diff_proc.stdout.splitlines()
+            if line.strip() and not line.strip().startswith("hidden/")
+        }
+
+    return status_files | diff_files
 
 
 def main() -> int:
@@ -49,17 +81,17 @@ def main() -> int:
     workdir = Path(payload["workdir"]).resolve()
     checks: list[tuple[str, bool, str]] = []
 
-    # 1. Run public tests
-    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
-    checks.append(("public tests pass", pub_ok, pub_out))
-
-    # 2. Run hidden tests if present
+    # 1. Run hidden tests first to prevent candidate code tampering
     hidden_test = workdir / "hidden" / "test_hidden.py"
     if hidden_test.exists():
         hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
         checks.append(("hidden boundary tests pass", hidden_ok, hidden_out))
     else:
         checks.append(("hidden boundary tests pass", False, "hidden test file missing"))
+
+    # 2. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
 
     # 3. Scope verification: only src/shipping.py changed
     changed = _changed_files(workdir)

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/grader/run.py
@@ -1,0 +1,82 @@
+"""Deterministic grader for retrieval-v1/retrieval-named-01.
+
+Verifies:
+1. Public tests pass (returncode == 0)
+2. Hidden boundary tests pass (returncode == 0)
+3. Only src/shipping.py changed (git status --porcelain)
+Does not check for "PASS" in stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(workdir: Path, *args: str) -> tuple[bool, str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    output = (result.stdout + result.stderr).strip()
+    return result.returncode == 0, output[-1_000:]
+
+
+def _changed_files(workdir: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    return {
+        line[3:].strip()
+        for line in result.stdout.splitlines()
+        if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
+    }
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    workdir = Path(payload["workdir"]).resolve()
+    checks: list[tuple[str, bool, str]] = []
+
+    # 1. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
+
+    # 2. Run hidden tests if present
+    hidden_test = workdir / "hidden" / "test_hidden.py"
+    if hidden_test.exists():
+        hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
+        checks.append(("hidden boundary tests pass", hidden_ok, hidden_out))
+    else:
+        checks.append(("hidden boundary tests pass", False, "hidden test file missing"))
+
+    # 3. Scope verification: only src/shipping.py changed
+    changed = _changed_files(workdir)
+    scope_ok = changed == {"src/shipping.py"}
+    checks.append(("only src/shipping.py changed", scope_ok, str(sorted(changed))))
+
+    passed = sum(ok for _, ok, _ in checks)
+    all_passed = passed == len(checks)
+    result = {
+        "passed": all_passed,
+        "score": passed / len(checks),
+        "evidence": [f"{name}: {'OK' if ok else 'FAIL'} {detail}" for name, ok, detail in checks],
+        "metadata": {"checks_total": len(checks), "checks_passed": passed},
+    }
+    print(json.dumps(result))
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/hidden/test_hidden.py
@@ -1,0 +1,20 @@
+"""Hidden boundary tests for shipping cost calculation."""
+from src.shipping import FLAT_RATE_CENTS, shipping_cost
+
+
+def test_boundary_below_threshold():
+    assert shipping_cost(7499) == FLAT_RATE_CENTS
+
+
+def test_boundary_exact_threshold():
+    assert shipping_cost(7500) == 0
+
+
+def test_boundary_above_threshold():
+    assert shipping_cost(7501) == 0
+
+
+def test_old_threshold_pays_flat_rate():
+    # An order of 6000 cents was incorrectly treated as free under > 5000 defect
+    assert shipping_cost(6000) == FLAT_RATE_CENTS
+    assert shipping_cost(5000) == FLAT_RATE_CENTS

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/hidden/test_hidden.py
@@ -3,18 +3,23 @@ from src.shipping import FLAT_RATE_CENTS, shipping_cost
 
 
 def test_boundary_below_threshold():
-    assert shipping_cost(7499) == FLAT_RATE_CENTS
+    if shipping_cost(7499) != FLAT_RATE_CENTS:
+        raise AssertionError("Expected flat rate for 7499 cents")
 
 
 def test_boundary_exact_threshold():
-    assert shipping_cost(7500) == 0
+    if shipping_cost(7500) != 0:
+        raise AssertionError("Expected free shipping for 7500 cents")
 
 
 def test_boundary_above_threshold():
-    assert shipping_cost(7501) == 0
+    if shipping_cost(7501) != 0:
+        raise AssertionError("Expected free shipping for 7501 cents")
 
 
 def test_old_threshold_pays_flat_rate():
     # An order of 6000 cents was incorrectly treated as free under > 5000 defect
-    assert shipping_cost(6000) == FLAT_RATE_CENTS
-    assert shipping_cost(5000) == FLAT_RATE_CENTS
+    if shipping_cost(6000) != FLAT_RATE_CENTS:
+        raise AssertionError("Expected flat rate for 6000 cents")
+    if shipping_cost(5000) != FLAT_RATE_CENTS:
+        raise AssertionError("Expected flat rate for 5000 cents")

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/policy.yaml
@@ -7,7 +7,6 @@ allowed_commands:
 allowed_read_paths:
   - "**"
 allowed_write_paths:
-  - "src/**"
-  - "tests/**"
+  - "src/shipping.py"
 network: none
 max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/policy.yaml
@@ -1,0 +1,13 @@
+profile: default
+allowed_commands:
+  - "python"
+  - "python3"
+  - "pytest"
+  - "git"
+allowed_read_paths:
+  - "**"
+allowed_write_paths:
+  - "src/**"
+  - "tests/**"
+network: none
+max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/prompt.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/prompt.md
@@ -1,0 +1,13 @@
+The free-shipping threshold in `src/shipping.py` has a seeded bug.
+
+Our store policy states:
+- Orders of **7500 cents** ($75.00) or more receive free shipping (shipping cost is 0).
+- Orders under 7500 cents pay the flat rate of 595 cents ($5.95).
+
+Currently `src/shipping.py` checks `order_cents > 5000` instead of `order_cents >= 7500`.
+
+Please fix the threshold condition in `src/shipping.py` so that:
+1. An order of exactly 7500 cents ships free.
+2. Orders below 7500 cents pay the flat rate.
+3. Only `src/shipping.py` is modified.
+4. All existing and boundary tests pass with `python -m pytest -q`.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/setup.sh
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/setup.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p src tests hidden
+cat > .gitignore <<'EOF'
+__pycache__/
+.pytest_cache/
+EOF
+
+touch src/__init__.py
+cat > src/shipping.py <<'PY'
+"""Shipping cost calculation with a seeded threshold defect."""
+
+FLAT_RATE_CENTS = 595
+
+
+def shipping_cost(order_cents: int) -> int:
+    """Return the shipping charge in cents for an order subtotal.
+
+    Policy: orders of 7500 cents ($75.00) or more ship free; smaller orders
+    pay the flat rate. The implementation below uses the wrong threshold.
+    """
+    if order_cents > 5000:
+        return 0
+    return FLAT_RATE_CENTS
+PY
+
+cat > tests/test_shipping.py <<'PY'
+from src.shipping import shipping_cost
+
+
+def test_small_order_pays_flat_rate():
+    assert shipping_cost(4000) == 595
+
+
+def test_clearly_large_order_ships_free():
+    assert shipping_cost(12000) == 0
+PY
+
+cat > justfile <<'JUST'
+test:
+    python3 -m pytest -q
+JUST
+
+if [ -f "$TERMINUS_TASK_DIR/hidden/test_hidden.py" ]; then
+  cp "$TERMINUS_TASK_DIR/hidden/test_hidden.py" hidden/test_hidden.py
+fi

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/task.yaml
@@ -26,5 +26,5 @@ acceptance_criteria:
 grader:
   entrypoint: grader/run.py
   protocol: json_stdio
-  timeout_seconds: 30
+  timeout_seconds: 60
 risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-01/task.yaml
@@ -1,0 +1,30 @@
+suite: retrieval-v1
+task: retrieval-named-01
+cohort: retrieval-v1
+title: Named file bug fix — free shipping threshold
+source_commit: fixture-retrieval-named-01-v1
+image_digest: local:python-3.12-pytest-8
+timeout: 600
+budget:
+  max_cost_usd: 1.0
+  max_wall_seconds: 600
+  max_tool_calls: 50
+  max_turns: 20
+allowed_network: []
+secrets: {}
+grader_version: 1.0.0
+rationale: >
+  Retrieval archetype 1: Explicitly named file.
+  The prompt directly mentions src/shipping.py and requests fixing the free-shipping threshold.
+acceptance_criteria:
+  - id: tests-pass
+    statement: the full test suite passes including hidden boundary tests
+    verification_hint: "command: python -m pytest -q"
+  - id: scope
+    statement: only src/shipping.py changed
+    verification_hint: "command: git status --porcelain"
+grader:
+  entrypoint: grader/run.py
+  protocol: json_stdio
+  timeout_seconds: 30
+risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/README.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/README.md
@@ -1,0 +1,5 @@
+# retrieval-named-02
+
+Archetype: Named file bug fix.
+The prompt mentions `src/ledger.py` by name. The agent must update `calculate_balance` so that transactions of type `"refund"` add to the balance rather than subtract from it.
+Hidden tests verify multiple refunds, mixed debits and deposits, and empty transaction lists.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/environment.lock
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/environment.lock
@@ -1,0 +1,2 @@
+python=3.12
+pytest=8.2.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/expected-properties.yaml
@@ -1,0 +1,11 @@
+properties:
+  - id: P-RETRIEVAL-NAMED-02-PASS
+    description: "The ledger test suite passes including hidden refund edge cases."
+    target_metric: "resolved"
+    direction: "maximize"
+    threshold: 1.0
+  - id: P-RETRIEVAL-NAMED-02-SCOPE
+    description: "Only src/ledger.py is modified by the agent."
+    target_metric: "scope_retained"
+    direction: "maximize"
+    threshold: 1.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/expected-properties.yaml
@@ -1,11 +1,15 @@
-properties:
-  - id: P-RETRIEVAL-NAMED-02-PASS
-    description: "The ledger test suite passes including hidden refund edge cases."
-    target_metric: "resolved"
-    direction: "maximize"
-    threshold: 1.0
-  - id: P-RETRIEVAL-NAMED-02-SCOPE
-    description: "Only src/ledger.py is modified by the agent."
-    target_metric: "scope_retained"
-    direction: "maximize"
-    threshold: 1.0
+expected:
+  outcome: completed
+  changed_files:
+    - src/ledger.py
+  tests:
+    - command: python -m pytest -q tests
+      status: passed
+    - command: python -m pytest -q hidden/test_hidden.py
+      status: passed
+  cost_usd_max: 0.10
+  turns_max: 5
+  rejection_triggers:
+    - changed_files outside [src/ledger.py]
+    - refund calculation defect still present
+    - public test regression

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/grader/run.py
@@ -1,0 +1,82 @@
+"""Deterministic grader for retrieval-v1/retrieval-named-02.
+
+Verifies:
+1. Public tests pass (returncode == 0)
+2. Hidden edge-case tests pass (returncode == 0)
+3. Only src/ledger.py changed (git status --porcelain)
+Does not check for "PASS" in stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(workdir: Path, *args: str) -> tuple[bool, str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    output = (result.stdout + result.stderr).strip()
+    return result.returncode == 0, output[-1_000:]
+
+
+def _changed_files(workdir: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    return {
+        line[3:].strip()
+        for line in result.stdout.splitlines()
+        if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
+    }
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    workdir = Path(payload["workdir"]).resolve()
+    checks: list[tuple[str, bool, str]] = []
+
+    # 1. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
+
+    # 2. Run hidden tests if present
+    hidden_test = workdir / "hidden" / "test_hidden.py"
+    if hidden_test.exists():
+        hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
+        checks.append(("hidden edge-case tests pass", hidden_ok, hidden_out))
+    else:
+        checks.append(("hidden edge-case tests pass", False, "hidden test file missing"))
+
+    # 3. Scope verification: only src/ledger.py changed
+    changed = _changed_files(workdir)
+    scope_ok = changed == {"src/ledger.py"}
+    checks.append(("only src/ledger.py changed", scope_ok, str(sorted(changed))))
+
+    passed = sum(ok for _, ok, _ in checks)
+    all_passed = passed == len(checks)
+    result = {
+        "passed": all_passed,
+        "score": passed / len(checks),
+        "evidence": [f"{name}: {'OK' if ok else 'FAIL'} {detail}" for name, ok, detail in checks],
+        "metadata": {"checks_total": len(checks), "checks_passed": passed},
+    }
+    print(json.dumps(result))
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/grader/run.py
@@ -1,15 +1,16 @@
 """Deterministic grader for retrieval-v1/retrieval-named-02.
 
 Verifies:
-1. Public tests pass (returncode == 0)
-2. Hidden edge-case tests pass (returncode == 0)
-3. Only src/ledger.py changed (git status --porcelain)
+1. Hidden edge-case tests pass (run first to prevent tampering)
+2. Public tests pass (returncode == 0)
+3. Only src/ledger.py changed (checks git status and commit diff)
 Does not check for "PASS" in stdout.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -21,7 +22,7 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
         cwd=workdir,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=60,
         check=False,
     )
     output = (result.stdout + result.stderr).strip()
@@ -29,19 +30,50 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
 
 
 def _changed_files(workdir: Path) -> set[str]:
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
+    git_bin = shutil.which("git") or "git"
+    # Check working tree (uncommitted/staged)
+    status_proc = subprocess.run(
+        [git_bin, "status", "--porcelain"],
         cwd=workdir,
         capture_output=True,
         text=True,
         timeout=20,
         check=False,
     )
-    return {
+    status_files = {
         line[3:].strip()
-        for line in result.stdout.splitlines()
+        for line in status_proc.stdout.splitlines()
         if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
     }
+
+    # Check committed changes against initial/base commit
+    log_proc = subprocess.run(
+        [git_bin, "log", "--reverse", "--format=%H"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    commits = [line.strip() for line in log_proc.stdout.splitlines() if line.strip()]
+    diff_files: set[str] = set()
+    if commits:
+        base_commit = commits[0]
+        diff_proc = subprocess.run(
+            [git_bin, "diff", "--name-only", base_commit, "HEAD"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        diff_files = {
+            line.strip()
+            for line in diff_proc.stdout.splitlines()
+            if line.strip() and not line.strip().startswith("hidden/")
+        }
+
+    return status_files | diff_files
 
 
 def main() -> int:
@@ -49,17 +81,17 @@ def main() -> int:
     workdir = Path(payload["workdir"]).resolve()
     checks: list[tuple[str, bool, str]] = []
 
-    # 1. Run public tests
-    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
-    checks.append(("public tests pass", pub_ok, pub_out))
-
-    # 2. Run hidden tests if present
+    # 1. Run hidden tests first to prevent candidate code tampering
     hidden_test = workdir / "hidden" / "test_hidden.py"
     if hidden_test.exists():
         hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
         checks.append(("hidden edge-case tests pass", hidden_ok, hidden_out))
     else:
         checks.append(("hidden edge-case tests pass", False, "hidden test file missing"))
+
+    # 2. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
 
     # 3. Scope verification: only src/ledger.py changed
     changed = _changed_files(workdir)

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/hidden/test_hidden.py
@@ -9,7 +9,8 @@ def test_multiple_refunds():
         {"type": "refund", "amount_cents": 1500},
     ]
     # 10000 + 2500 + 1500 = 14000
-    assert calculate_balance(txs) == 14000
+    if calculate_balance(txs) != 14000:
+        raise AssertionError(f"Expected 14000 cents, got {calculate_balance(txs)}")
 
 
 def test_mixed_transactions():
@@ -20,9 +21,16 @@ def test_mixed_transactions():
         {"type": "refund", "amount_cents": 350},
     ]
     # 5000 - 2000 - 150 + 350 = 3200
-    assert calculate_balance(txs) == 3200
+    if calculate_balance(txs) != 3200:
+        raise AssertionError(f"Expected 3200 cents, got {calculate_balance(txs)}")
 
 
 def test_refund_only():
     txs = [{"type": "refund", "amount_cents": 1250}]
-    assert calculate_balance(txs) == 1250
+    if calculate_balance(txs) != 1250:
+        raise AssertionError(f"Expected 1250 cents, got {calculate_balance(txs)}")
+
+
+def test_empty_transactions():
+    if calculate_balance([]) != 0:
+        raise AssertionError("Expected balance 0 for empty transaction list")

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/hidden/test_hidden.py
@@ -1,0 +1,28 @@
+"""Hidden edge-case tests for ledger calculations."""
+from src.ledger import calculate_balance
+
+
+def test_multiple_refunds():
+    txs = [
+        {"type": "deposit", "amount_cents": 10000},
+        {"type": "refund", "amount_cents": 2500},
+        {"type": "refund", "amount_cents": 1500},
+    ]
+    # 10000 + 2500 + 1500 = 14000
+    assert calculate_balance(txs) == 14000
+
+
+def test_mixed_transactions():
+    txs = [
+        {"type": "deposit", "amount_cents": 5000},
+        {"type": "withdrawal", "amount_cents": 2000},
+        {"type": "fee", "amount_cents": 150},
+        {"type": "refund", "amount_cents": 350},
+    ]
+    # 5000 - 2000 - 150 + 350 = 3200
+    assert calculate_balance(txs) == 3200
+
+
+def test_refund_only():
+    txs = [{"type": "refund", "amount_cents": 1250}]
+    assert calculate_balance(txs) == 1250

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/policy.yaml
@@ -7,7 +7,6 @@ allowed_commands:
 allowed_read_paths:
   - "**"
 allowed_write_paths:
-  - "src/**"
-  - "tests/**"
+  - "src/ledger.py"
 network: none
 max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/policy.yaml
@@ -1,0 +1,13 @@
+profile: default
+allowed_commands:
+  - "python"
+  - "python3"
+  - "pytest"
+  - "git"
+allowed_read_paths:
+  - "**"
+allowed_write_paths:
+  - "src/**"
+  - "tests/**"
+network: none
+max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/prompt.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/prompt.md
@@ -1,0 +1,14 @@
+A bug was reported in `src/ledger.py` regarding balance calculations for refunded transactions.
+
+In `src/ledger.py`:
+- `calculate_balance(transactions)` computes an account balance in cents.
+- Deposits should increase the balance.
+- Withdrawals and fees should decrease the balance.
+- Refunds should **increase** the balance (restoring customer funds).
+
+Currently, `calculate_balance` incorrectly subtracts refunds instead of adding them.
+
+Please fix `src/ledger.py` so that:
+1. `type == "refund"` adds `amount_cents` to the balance.
+2. Only `src/ledger.py` is modified.
+3. All tests pass with `python -m pytest -q`.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/setup.sh
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/setup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p src tests hidden
+cat > .gitignore <<'EOF'
+__pycache__/
+.pytest_cache/
+EOF
+
+touch src/__init__.py
+cat > src/ledger.py <<'PY'
+"""Ledger balance calculations with a seeded refund subtraction bug."""
+
+from typing import Any, List, Dict
+
+
+def calculate_balance(transactions: List[Dict[str, Any]]) -> int:
+    """Calculate the net balance in cents from a sequence of transactions.
+
+    Supported types:
+      - "deposit": adds funds to the account
+      - "withdrawal": removes funds from the account
+      - "fee": deduction from the account
+      - "refund": restores funds back into the account
+
+    DEFECT: The implementation below erroneously subtracts refunds instead
+    of adding them.
+    """
+    balance = 0
+    for tx in transactions:
+        tx_type = tx.get("type")
+        amount = tx.get("amount_cents", 0)
+        if tx_type == "deposit":
+            balance += amount
+        elif tx_type in ("withdrawal", "fee"):
+            balance -= amount
+        elif tx_type == "refund":
+            # Seeded bug: should be balance += amount
+            balance -= amount
+    return balance
+PY
+
+cat > tests/test_ledger.py <<'PY'
+from src.ledger import calculate_balance
+
+
+def test_empty_ledger():
+    assert calculate_balance([]) == 0
+
+
+def test_deposit_and_withdrawal():
+    txs = [
+        {"type": "deposit", "amount_cents": 5000},
+        {"type": "withdrawal", "amount_cents": 1200},
+    ]
+    assert calculate_balance(txs) == 3800
+PY
+
+cat > justfile <<'JUST'
+test:
+    python3 -m pytest -q
+JUST
+
+if [ -f "$TERMINUS_TASK_DIR/hidden/test_hidden.py" ]; then
+  cp "$TERMINUS_TASK_DIR/hidden/test_hidden.py" hidden/test_hidden.py
+fi

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/task.yaml
@@ -26,5 +26,5 @@ acceptance_criteria:
 grader:
   entrypoint: grader/run.py
   protocol: json_stdio
-  timeout_seconds: 30
+  timeout_seconds: 60
 risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-named-02/task.yaml
@@ -1,0 +1,30 @@
+suite: retrieval-v1
+task: retrieval-named-02
+cohort: retrieval-v1
+title: Named file bug fix — ledger balance refund calculation
+source_commit: fixture-retrieval-named-02-v1
+image_digest: local:python-3.12-pytest-8
+timeout: 600
+budget:
+  max_cost_usd: 1.0
+  max_wall_seconds: 600
+  max_tool_calls: 50
+  max_turns: 20
+allowed_network: []
+secrets: {}
+grader_version: 1.0.0
+rationale: >
+  Retrieval archetype 1: Explicitly named file.
+  The prompt directly mentions src/ledger.py and asks to fix refund balance handling.
+acceptance_criteria:
+  - id: tests-pass
+    statement: the full test suite passes including hidden edge cases
+    verification_hint: "command: python -m pytest -q"
+  - id: scope
+    statement: only src/ledger.py changed
+    verification_hint: "command: git status --porcelain"
+grader:
+  entrypoint: grader/run.py
+  protocol: json_stdio
+  timeout_seconds: 30
+risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/README.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/README.md
@@ -1,0 +1,6 @@
+# retrieval-symptom-01
+
+Archetype: Code located from symptoms or behavior.
+The prompt mentions no file names, describing only the symptom: customers getting double charged on timeout.
+The agent must search across multiple modules to locate `src/payments.py:charge_with_retry`, fix the idempotency key regeneration bug, and record the findings in `DISCOVERY.json`.
+Hidden tests verify retry key consistency under mock network timeouts.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/environment.lock
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/environment.lock
@@ -1,0 +1,2 @@
+python=3.12
+pytest=8.2.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/expected-properties.yaml
@@ -1,0 +1,16 @@
+properties:
+  - id: P-RETRIEVAL-SYMPTOM-01-DISCOVERY
+    description: "DISCOVERY.json identifies src/payments.py as the offending file."
+    target_metric: "resolved"
+    direction: "maximize"
+    threshold: 1.0
+  - id: P-RETRIEVAL-SYMPTOM-01-PASS
+    description: "The payment test suite passes including hidden retry tests."
+    target_metric: "resolved"
+    direction: "maximize"
+    threshold: 1.0
+  - id: P-RETRIEVAL-SYMPTOM-01-SCOPE
+    description: "Only src/payments.py and DISCOVERY.json are modified."
+    target_metric: "scope_retained"
+    direction: "maximize"
+    threshold: 1.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/expected-properties.yaml
@@ -1,16 +1,17 @@
-properties:
-  - id: P-RETRIEVAL-SYMPTOM-01-DISCOVERY
-    description: "DISCOVERY.json identifies src/payments.py as the offending file."
-    target_metric: "resolved"
-    direction: "maximize"
-    threshold: 1.0
-  - id: P-RETRIEVAL-SYMPTOM-01-PASS
-    description: "The payment test suite passes including hidden retry tests."
-    target_metric: "resolved"
-    direction: "maximize"
-    threshold: 1.0
-  - id: P-RETRIEVAL-SYMPTOM-01-SCOPE
-    description: "Only src/payments.py and DISCOVERY.json are modified."
-    target_metric: "scope_retained"
-    direction: "maximize"
-    threshold: 1.0
+expected:
+  outcome: completed
+  changed_files:
+    - src/payments.py
+    - DISCOVERY.json
+  tests:
+    - command: python -m pytest -q tests
+      status: passed
+    - command: python -m pytest -q hidden/test_hidden.py
+      status: passed
+  cost_usd_max: 0.15
+  turns_max: 6
+  rejection_triggers:
+    - changed_files outside [src/payments.py, DISCOVERY.json]
+    - DISCOVERY.json missing or incomplete
+    - payment retry defect still present
+    - public test regression

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/grader/run.py
@@ -1,0 +1,102 @@
+"""Deterministic grader for retrieval-v1/retrieval-symptom-01.
+
+Verifies:
+1. DISCOVERY.json correctly identifies src/payments.py and charge_with_retry
+2. Full test suite (public + hidden timeout retry test) passes (returncode == 0)
+3. Scope: only src/payments.py and DISCOVERY.json changed
+Does not check for "PASS" in stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(workdir: Path, *args: str) -> tuple[bool, str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    output = (result.stdout + result.stderr).strip()
+    return result.returncode == 0, output[-1_000:]
+
+
+def _changed_files(workdir: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    return {
+        line[3:].strip()
+        for line in result.stdout.splitlines()
+        if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
+    }
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    workdir = Path(payload["workdir"]).resolve()
+    checks: list[tuple[str, bool, str]] = []
+
+    # 1. Inspect DISCOVERY.json
+    discovery_file = workdir / "DISCOVERY.json"
+    discovery_ok = False
+    discovery_msg = "missing DISCOVERY.json"
+    if discovery_file.exists():
+        try:
+            with open(discovery_file, encoding="utf-8") as f:
+                data = json.load(f)
+            offending = str(data.get("offending_file", "")).strip().lstrip("./")
+            func = str(data.get("function_name", "")).strip()
+            if offending == "src/payments.py" and func == "charge_with_retry":
+                discovery_ok = True
+                discovery_msg = f"valid discovery: {offending} -> {func}"
+            else:
+                discovery_msg = f"mismatched discovery fields: offending={offending}, func={func}"
+        except Exception as e:
+            discovery_msg = f"failed to parse DISCOVERY.json: {e}"
+    checks.append(("DISCOVERY.json valid", discovery_ok, discovery_msg))
+
+    # 2. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
+
+    # 3. Run hidden tests if present
+    hidden_test = workdir / "hidden" / "test_hidden.py"
+    if hidden_test.exists():
+        hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
+        checks.append(("hidden retry tests pass", hidden_ok, hidden_out))
+    else:
+        checks.append(("hidden retry tests pass", False, "hidden test file missing"))
+
+    # 4. Scope verification
+    changed = _changed_files(workdir)
+    allowed_changed = {"src/payments.py", "DISCOVERY.json"}
+    scope_ok = changed.issubset(allowed_changed) and "src/payments.py" in changed
+    checks.append(("scope enforcement (only payments.py and DISCOVERY.json)", scope_ok, str(sorted(changed))))
+
+    passed = sum(ok for _, ok, _ in checks)
+    all_passed = passed == len(checks)
+    result = {
+        "passed": all_passed,
+        "score": passed / len(checks),
+        "evidence": [f"{name}: {'OK' if ok else 'FAIL'} {detail}" for name, ok, detail in checks],
+        "metadata": {"checks_total": len(checks), "checks_passed": passed},
+    }
+    print(json.dumps(result))
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/grader/run.py
@@ -1,15 +1,17 @@
 """Deterministic grader for retrieval-v1/retrieval-symptom-01.
 
 Verifies:
-1. DISCOVERY.json correctly identifies src/payments.py and charge_with_retry
-2. Full test suite (public + hidden timeout retry test) passes (returncode == 0)
-3. Scope: only src/payments.py and DISCOVERY.json changed
+1. DISCOVERY.json correctly identifies src/payments.py, charge_with_retry, and non-empty root_cause
+2. Hidden retry tests pass (run first to prevent tampering)
+3. Public tests pass (returncode == 0)
+4. Scope: only src/payments.py and DISCOVERY.json changed
 Does not check for "PASS" in stdout.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -21,7 +23,7 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
         cwd=workdir,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=60,
         check=False,
     )
     output = (result.stdout + result.stderr).strip()
@@ -29,19 +31,50 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
 
 
 def _changed_files(workdir: Path) -> set[str]:
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
+    git_bin = shutil.which("git") or "git"
+    # Check working tree (uncommitted/staged)
+    status_proc = subprocess.run(
+        [git_bin, "status", "--porcelain"],
         cwd=workdir,
         capture_output=True,
         text=True,
         timeout=20,
         check=False,
     )
-    return {
+    status_files = {
         line[3:].strip()
-        for line in result.stdout.splitlines()
+        for line in status_proc.stdout.splitlines()
         if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
     }
+
+    # Check committed changes against initial/base commit
+    log_proc = subprocess.run(
+        [git_bin, "log", "--reverse", "--format=%H"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    commits = [line.strip() for line in log_proc.stdout.splitlines() if line.strip()]
+    diff_files: set[str] = set()
+    if commits:
+        base_commit = commits[0]
+        diff_proc = subprocess.run(
+            [git_bin, "diff", "--name-only", base_commit, "HEAD"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        diff_files = {
+            line.strip()
+            for line in diff_proc.stdout.splitlines()
+            if line.strip() and not line.strip().startswith("hidden/")
+        }
+
+    return status_files | diff_files
 
 
 def main() -> int:
@@ -59,26 +92,30 @@ def main() -> int:
                 data = json.load(f)
             offending = str(data.get("offending_file", "")).strip().lstrip("./")
             func = str(data.get("function_name", "")).strip()
-            if offending == "src/payments.py" and func == "charge_with_retry":
+            root_cause = str(data.get("root_cause", "")).strip()
+            if offending == "src/payments.py" and func == "charge_with_retry" and len(root_cause) >= 5:
                 discovery_ok = True
-                discovery_msg = f"valid discovery: {offending} -> {func}"
+                discovery_msg = f"valid discovery: {offending} -> {func} (root cause: {root_cause[:40]}...)"
             else:
-                discovery_msg = f"mismatched discovery fields: offending={offending}, func={func}"
+                discovery_msg = (
+                    f"mismatched discovery fields: offending={offending}, func={func}, "
+                    f"root_cause_len={len(root_cause)}"
+                )
         except Exception as e:
             discovery_msg = f"failed to parse DISCOVERY.json: {e}"
     checks.append(("DISCOVERY.json valid", discovery_ok, discovery_msg))
 
-    # 2. Run public tests
-    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
-    checks.append(("public tests pass", pub_ok, pub_out))
-
-    # 3. Run hidden tests if present
+    # 2. Run hidden tests first to prevent candidate code tampering
     hidden_test = workdir / "hidden" / "test_hidden.py"
     if hidden_test.exists():
         hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
         checks.append(("hidden retry tests pass", hidden_ok, hidden_out))
     else:
         checks.append(("hidden retry tests pass", False, "hidden test file missing"))
+
+    # 3. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
 
     # 4. Scope verification
     changed = _changed_files(workdir)

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/hidden/test_hidden.py
@@ -1,0 +1,30 @@
+"""Hidden tests verifying idempotency key reuse during network timeouts."""
+from src.payments import PaymentGatewayTimeout, charge_with_retry
+
+
+class FlakyGateway:
+    def __init__(self, fail_times=1):
+        self.fail_times = fail_times
+        self.attempts = []
+
+    def charge(self, amount: int, idempotency_key: str):
+        self.attempts.append(idempotency_key)
+        if len(self.attempts) <= self.fail_times:
+            raise PaymentGatewayTimeout("Gateway timed out")
+        return {"status": "succeeded", "charge_id": "ch_123", "key": idempotency_key}
+
+
+def test_retry_reuses_exact_same_idempotency_key():
+    gateway = FlakyGateway(fail_times=2)
+    result = charge_with_retry(
+        gateway=gateway,
+        amount=5000,
+        customer_id="cust_abc",
+        max_retries=3,
+    )
+    assert result["status"] == "succeeded"
+    assert len(gateway.attempts) == 3
+    # All 3 attempts MUST share the identical idempotency key!
+    first_key = gateway.attempts[0]
+    for key in gateway.attempts:
+        assert key == first_key, f"Idempotency key changed across retries: {gateway.attempts}"

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/hidden/test_hidden.py
@@ -22,9 +22,12 @@ def test_retry_reuses_exact_same_idempotency_key():
         customer_id="cust_abc",
         max_retries=3,
     )
-    assert result["status"] == "succeeded"
-    assert len(gateway.attempts) == 3
+    if result["status"] != "succeeded":
+        raise AssertionError(f"Expected status succeeded, got {result['status']}")
+    if len(gateway.attempts) != 3:
+        raise AssertionError(f"Expected 3 attempts, got {len(gateway.attempts)}")
     # All 3 attempts MUST share the identical idempotency key!
     first_key = gateway.attempts[0]
     for key in gateway.attempts:
-        assert key == first_key, f"Idempotency key changed across retries: {gateway.attempts}"
+        if key != first_key:
+            raise AssertionError(f"Idempotency key changed across retries: {gateway.attempts}")

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/policy.yaml
@@ -7,8 +7,7 @@ allowed_commands:
 allowed_read_paths:
   - "**"
 allowed_write_paths:
-  - "src/**"
-  - "tests/**"
+  - "src/payments.py"
   - "DISCOVERY.json"
 network: none
 max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/policy.yaml
@@ -1,0 +1,14 @@
+profile: default
+allowed_commands:
+  - "python"
+  - "python3"
+  - "pytest"
+  - "git"
+allowed_read_paths:
+  - "**"
+allowed_write_paths:
+  - "src/**"
+  - "tests/**"
+  - "DISCOVERY.json"
+network: none
+max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/prompt.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/prompt.md
@@ -1,0 +1,16 @@
+Customer support has escalated an urgent issue:
+"Customers report getting double-charged whenever an initial payment attempt experiences a network timeout."
+
+Investigate the codebase to diagnose and resolve this bug:
+1. Locate where payment retries are implemented.
+2. Determine why a network timeout causes a double charge rather than an idempotent retry.
+3. Fix the retry mechanism so that retried charge attempts reuse the original idempotency key rather than creating a new one.
+4. Create a file named `DISCOVERY.json` in the root of the repository with the following JSON schema:
+   ```json
+   {
+     "offending_file": "relative/path/to/file.py",
+     "function_name": "name_of_function",
+     "root_cause": "description of why the bug occurred"
+   }
+   ```
+5. Ensure all existing and new tests pass with `python -m pytest -q`.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/prompt.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/prompt.md
@@ -14,3 +14,4 @@ Investigate the codebase to diagnose and resolve this bug:
    }
    ```
 5. Ensure all existing and new tests pass with `python -m pytest -q`.
+6. Only modify `src/payments.py` and write `DISCOVERY.json`. Do not edit tests or any other files.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/setup.sh
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/setup.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p src tests hidden
+cat > .gitignore <<'EOF'
+__pycache__/
+.pytest_cache/
+EOF
+
+touch src/__init__.py
+
+cat > src/auth.py <<'PY'
+"""Authentication and token validation."""
+
+def verify_api_token(token: str) -> bool:
+    return len(token) >= 16 and token.startswith("sec_")
+PY
+
+cat > src/database.py <<'PY'
+"""Database access records."""
+
+class TransactionStore:
+    def __init__(self):
+        self._records = []
+
+    def record_attempt(self, key: str, amount: int):
+        self._records.append({"key": key, "amount": amount})
+PY
+
+cat > src/receipts.py <<'PY'
+"""Receipt dispatching service."""
+
+def send_receipt(customer_email: str, amount_cents: int) -> bool:
+    return True
+PY
+
+cat > src/payments.py <<'PY'
+"""Payment processing service with retry logic."""
+
+import uuid
+
+
+class PaymentGatewayTimeout(Exception):
+    pass
+
+
+def generate_idempotency_key(customer_id: str, amount: int) -> str:
+    return f"idem_{customer_id}_{amount}_{uuid.uuid4().hex[:12]}"
+
+
+def charge_with_retry(gateway, amount: int, customer_id: str, max_retries: int = 3):
+    """Attempt a payment charge with automatic retries on gateway timeouts.
+
+    DEFECT: Each retry iteration calls generate_idempotency_key(), minting a
+    new key. If an earlier timed-out attempt actually succeeded upstream, the
+    provider processes the retry as a distinct charge, resulting in a duplicate
+    charge!
+    """
+    last_error = None
+    for attempt in range(max_retries):
+        # Seeded bug: key is regenerated on every attempt inside the loop!
+        key = generate_idempotency_key(customer_id, amount)
+        try:
+            return gateway.charge(amount=amount, idempotency_key=key)
+        except PaymentGatewayTimeout as err:
+            last_error = err
+    raise last_error or Exception("Max retries exceeded")
+PY
+
+cat > tests/test_payments.py <<'PY'
+from src.payments import charge_with_retry
+
+
+class MockGateway:
+    def __init__(self):
+        self.attempts = []
+
+    def charge(self, amount: int, idempotency_key: str):
+        self.attempts.append(idempotency_key)
+        return {"status": "succeeded", "key": idempotency_key}
+
+
+def test_successful_charge_single_attempt():
+    gateway = MockGateway()
+    res = charge_with_retry(gateway, 2500, "cust_1")
+    assert res["status"] == "succeeded"
+    assert len(gateway.attempts) == 1
+PY
+
+cat > justfile <<'JUST'
+test:
+    python3 -m pytest -q
+JUST
+
+if [ -f "$TERMINUS_TASK_DIR/hidden/test_hidden.py" ]; then
+  cp "$TERMINUS_TASK_DIR/hidden/test_hidden.py" hidden/test_hidden.py
+fi

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/task.yaml
@@ -31,5 +31,5 @@ acceptance_criteria:
 grader:
   entrypoint: grader/run.py
   protocol: json_stdio
-  timeout_seconds: 30
+  timeout_seconds: 60
 risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-01/task.yaml
@@ -1,0 +1,35 @@
+suite: retrieval-v1
+task: retrieval-symptom-01
+cohort: retrieval-v1
+title: Symptom-based localization — payment timeout duplicate charge
+source_commit: fixture-retrieval-symptom-01-v1
+image_digest: local:python-3.12-pytest-8
+timeout: 600
+budget:
+  max_cost_usd: 1.0
+  max_wall_seconds: 600
+  max_tool_calls: 50
+  max_turns: 20
+allowed_network: []
+secrets: {}
+grader_version: 1.0.0
+rationale: >
+  Retrieval archetype 2: Code located from symptoms or behavior.
+  The prompt describes customer symptom of double-charging during timeouts.
+  No file names are provided in the prompt. The agent must locate the retry mechanism,
+  fix the key reuse bug, and produce a DISCOVERY.json artifact.
+acceptance_criteria:
+  - id: discovery-artifact
+    statement: DISCOVERY.json correctly identifies the offending file and function
+    verification_hint: "inspection: DISCOVERY.json exists with valid JSON"
+  - id: tests-pass
+    statement: the full test suite passes including hidden timeout retry tests
+    verification_hint: "command: python -m pytest -q"
+  - id: scope
+    statement: only the payment module and DISCOVERY.json changed
+    verification_hint: "command: git status --porcelain"
+grader:
+  entrypoint: grader/run.py
+  protocol: json_stdio
+  timeout_seconds: 30
+risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/README.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/README.md
@@ -1,0 +1,6 @@
+# retrieval-symptom-02
+
+Archetype: Code located from symptoms or behavior.
+The prompt mentions no file names, only the ValueError traceback during batch parsing.
+The agent must search through server, database, exporter, and parser files to locate `src/batch_parser.py`, fix blank line and comment skipping, and keep the changes confined to that file.
+Hidden tests verify multiple empty lines, whitespace-only lines, comment headers, and trailing blanks.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/environment.lock
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/environment.lock
@@ -1,0 +1,2 @@
+python=3.12
+pytest=8.2.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/expected-properties.yaml
@@ -1,0 +1,11 @@
+properties:
+  - id: P-RETRIEVAL-SYMPTOM-02-PASS
+    description: "The batch parser test suite passes including hidden blank line and comment checks."
+    target_metric: "resolved"
+    direction: "maximize"
+    threshold: 1.0
+  - id: P-RETRIEVAL-SYMPTOM-02-SCOPE
+    description: "Only src/batch_parser.py is modified by the agent."
+    target_metric: "scope_retained"
+    direction: "maximize"
+    threshold: 1.0

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/expected-properties.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/expected-properties.yaml
@@ -1,11 +1,15 @@
-properties:
-  - id: P-RETRIEVAL-SYMPTOM-02-PASS
-    description: "The batch parser test suite passes including hidden blank line and comment checks."
-    target_metric: "resolved"
-    direction: "maximize"
-    threshold: 1.0
-  - id: P-RETRIEVAL-SYMPTOM-02-SCOPE
-    description: "Only src/batch_parser.py is modified by the agent."
-    target_metric: "scope_retained"
-    direction: "maximize"
-    threshold: 1.0
+expected:
+  outcome: completed
+  changed_files:
+    - src/batch_parser.py
+  tests:
+    - command: python -m pytest -q tests
+      status: passed
+    - command: python -m pytest -q hidden/test_hidden.py
+      status: passed
+  cost_usd_max: 0.10
+  turns_max: 5
+  rejection_triggers:
+    - changed_files outside [src/batch_parser.py]
+    - batch parser blank line defect still present
+    - public test regression

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/grader/run.py
@@ -1,0 +1,81 @@
+"""Deterministic grader for retrieval-v1/retrieval-symptom-02.
+
+Verifies:
+1. Full test suite (public + hidden blank line / comment checks) passes (returncode == 0)
+2. Scope: only src/batch_parser.py changed
+Does not check for "PASS" in stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(workdir: Path, *args: str) -> tuple[bool, str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    output = (result.stdout + result.stderr).strip()
+    return result.returncode == 0, output[-1_000:]
+
+
+def _changed_files(workdir: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    return {
+        line[3:].strip()
+        for line in result.stdout.splitlines()
+        if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
+    }
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    workdir = Path(payload["workdir"]).resolve()
+    checks: list[tuple[str, bool, str]] = []
+
+    # 1. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
+
+    # 2. Run hidden tests if present
+    hidden_test = workdir / "hidden" / "test_hidden.py"
+    if hidden_test.exists():
+        hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
+        checks.append(("hidden blank-line & comment tests pass", hidden_ok, hidden_out))
+    else:
+        checks.append(("hidden blank-line & comment tests pass", False, "hidden test file missing"))
+
+    # 3. Scope verification: only src/batch_parser.py changed
+    changed = _changed_files(workdir)
+    scope_ok = changed == {"src/batch_parser.py"}
+    checks.append(("only src/batch_parser.py changed", scope_ok, str(sorted(changed))))
+
+    passed = sum(ok for _, ok, _ in checks)
+    all_passed = passed == len(checks)
+    result = {
+        "passed": all_passed,
+        "score": passed / len(checks),
+        "evidence": [f"{name}: {'OK' if ok else 'FAIL'} {detail}" for name, ok, detail in checks],
+        "metadata": {"checks_total": len(checks), "checks_passed": passed},
+    }
+    print(json.dumps(result))
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/grader/run.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/grader/run.py
@@ -1,14 +1,16 @@
 """Deterministic grader for retrieval-v1/retrieval-symptom-02.
 
 Verifies:
-1. Full test suite (public + hidden blank line / comment checks) passes (returncode == 0)
-2. Scope: only src/batch_parser.py changed
+1. Hidden blank-line & comment tests pass (run first to prevent tampering)
+2. Public tests pass (returncode == 0)
+3. Scope: only src/batch_parser.py changed (checks git status and commit diff)
 Does not check for "PASS" in stdout.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -20,7 +22,7 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
         cwd=workdir,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=60,
         check=False,
     )
     output = (result.stdout + result.stderr).strip()
@@ -28,19 +30,50 @@ def _run(workdir: Path, *args: str) -> tuple[bool, str]:
 
 
 def _changed_files(workdir: Path) -> set[str]:
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
+    git_bin = shutil.which("git") or "git"
+    # Check working tree (uncommitted/staged)
+    status_proc = subprocess.run(
+        [git_bin, "status", "--porcelain"],
         cwd=workdir,
         capture_output=True,
         text=True,
         timeout=20,
         check=False,
     )
-    return {
+    status_files = {
         line[3:].strip()
-        for line in result.stdout.splitlines()
+        for line in status_proc.stdout.splitlines()
         if len(line) >= 3 and not line[3:].strip().startswith("hidden/")
     }
+
+    # Check committed changes against initial/base commit
+    log_proc = subprocess.run(
+        [git_bin, "log", "--reverse", "--format=%H"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    commits = [line.strip() for line in log_proc.stdout.splitlines() if line.strip()]
+    diff_files: set[str] = set()
+    if commits:
+        base_commit = commits[0]
+        diff_proc = subprocess.run(
+            [git_bin, "diff", "--name-only", base_commit, "HEAD"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        diff_files = {
+            line.strip()
+            for line in diff_proc.stdout.splitlines()
+            if line.strip() and not line.strip().startswith("hidden/")
+        }
+
+    return status_files | diff_files
 
 
 def main() -> int:
@@ -48,17 +81,17 @@ def main() -> int:
     workdir = Path(payload["workdir"]).resolve()
     checks: list[tuple[str, bool, str]] = []
 
-    # 1. Run public tests
-    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
-    checks.append(("public tests pass", pub_ok, pub_out))
-
-    # 2. Run hidden tests if present
+    # 1. Run hidden tests first to prevent candidate code tampering
     hidden_test = workdir / "hidden" / "test_hidden.py"
     if hidden_test.exists():
         hidden_ok, hidden_out = _run(workdir, "-m", "pytest", "-q", str(hidden_test))
         checks.append(("hidden blank-line & comment tests pass", hidden_ok, hidden_out))
     else:
         checks.append(("hidden blank-line & comment tests pass", False, "hidden test file missing"))
+
+    # 2. Run public tests
+    pub_ok, pub_out = _run(workdir, "-m", "pytest", "-q", "tests")
+    checks.append(("public tests pass", pub_ok, pub_out))
 
     # 3. Scope verification: only src/batch_parser.py changed
     changed = _changed_files(workdir)

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/hidden/test_hidden.py
@@ -15,11 +15,13 @@ def test_batch_with_comments_and_whitespace():
     
     """
     items = parse_batch_items(input_text)
-    assert items == [
+    expected = [
         {"item_id": 101, "quantity": 5},
         {"item_id": 102, "quantity": 12},
         {"item_id": 103, "quantity": 99},
     ]
+    if items != expected:
+        raise AssertionError(f"Expected {expected}, got {items}")
 
 
 def test_all_empty_or_comments():
@@ -28,4 +30,5 @@ def test_all_empty_or_comments():
     # Nothing else
     
     """
-    assert parse_batch_items(input_text) == []
+    if parse_batch_items(input_text) != []:
+        raise AssertionError("Expected empty list for empty/comments input")

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/hidden/test_hidden.py
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/hidden/test_hidden.py
@@ -1,0 +1,31 @@
+"""Hidden tests for batch parser with comments, blank lines, and whitespace."""
+from src.batch_parser import parse_batch_items
+
+
+def test_batch_with_comments_and_whitespace():
+    input_text = """
+    # Inventory import batch 2026-09
+    101, 5
+    # The following item is restocked
+       
+    102, 12
+    
+    103, 99
+    # End of batch
+    
+    """
+    items = parse_batch_items(input_text)
+    assert items == [
+        {"item_id": 101, "quantity": 5},
+        {"item_id": 102, "quantity": 12},
+        {"item_id": 103, "quantity": 99},
+    ]
+
+
+def test_all_empty_or_comments():
+    input_text = """
+    # Just comments
+    # Nothing else
+    
+    """
+    assert parse_batch_items(input_text) == []

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/policy.yaml
@@ -7,7 +7,6 @@ allowed_commands:
 allowed_read_paths:
   - "**"
 allowed_write_paths:
-  - "src/**"
-  - "tests/**"
+  - "src/batch_parser.py"
 network: none
 max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/policy.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/policy.yaml
@@ -1,0 +1,13 @@
+profile: default
+allowed_commands:
+  - "python"
+  - "python3"
+  - "pytest"
+  - "git"
+allowed_read_paths:
+  - "**"
+allowed_write_paths:
+  - "src/**"
+  - "tests/**"
+network: none
+max_memory_mb: 1024

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/prompt.md
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/prompt.md
@@ -1,0 +1,17 @@
+Our backend data processing service is failing on imported batch files with the following traceback:
+
+```text
+Traceback (most recent call last):
+  ...
+ValueError: invalid literal for int() with base 10: ''
+```
+
+Customers often leave trailing blank lines, empty whitespace lines, or comment lines starting with `#` in their batch upload files.
+
+Please diagnose the codebase to find where batch input is parsed, and update the parser to:
+1. Strip leading and trailing whitespace from each line.
+2. Ignore empty or blank lines.
+3. Ignore comment lines where the first non-whitespace character is `#`.
+4. Successfully parse valid integer ID and quantity columns.
+5. Ensure only the responsible parser file is modified.
+6. Verify all tests pass with `python -m pytest -q`.

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/setup.sh
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/setup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p src tests hidden
+cat > .gitignore <<'EOF'
+__pycache__/
+.pytest_cache/
+EOF
+
+touch src/__init__.py
+
+cat > src/server.py <<'PY'
+"""API server routes for inventory ingestion."""
+
+def handle_upload_request(payload: str):
+    return {"status": "received", "bytes": len(payload)}
+PY
+
+cat > src/database.py <<'PY'
+"""Database storage for inventory items."""
+
+def upsert_item(item_id: int, quantity: int):
+    return True
+PY
+
+cat > src/exporter.py <<'PY'
+"""Data export routines."""
+
+def export_csv(rows: list):
+    return "\n".join(",".join(map(str, r)) for r in rows)
+PY
+
+cat > src/batch_parser.py <<'PY'
+"""Batch input parser for comma-separated integer pairs."""
+
+from typing import List, Dict
+
+
+def parse_batch_items(raw_text: str) -> List[Dict[str, int]]:
+    """Parse lines of item_id, quantity into structured dictionaries.
+
+    DEFECT: Iterates raw lines directly. When lines are blank or contain
+    comments, int(parts[0]) throws ValueError: invalid literal for int() with base 10: ''.
+    """
+    results = []
+    lines = raw_text.splitlines()
+    for line in lines:
+        # Seeded defect: fails to strip whitespace, skip empty lines, or skip # comments
+        parts = line.split(",")
+        item_id = int(parts[0])
+        quantity = int(parts[1])
+        results.append({"item_id": item_id, "quantity": quantity})
+    return results
+PY
+
+cat > tests/test_batch_parser.py <<'PY'
+from src.batch_parser import parse_batch_items
+
+
+def test_clean_input():
+    data = "1,10\n2,20\n3,30"
+    items = parse_batch_items(data)
+    assert len(items) == 3
+    assert items[0] == {"item_id": 1, "quantity": 10}
+PY
+
+cat > justfile <<'JUST'
+test:
+    python3 -m pytest -q
+JUST
+
+if [ -f "$TERMINUS_TASK_DIR/hidden/test_hidden.py" ]; then
+  cp "$TERMINUS_TASK_DIR/hidden/test_hidden.py" hidden/test_hidden.py
+fi

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/task.yaml
@@ -1,0 +1,32 @@
+suite: retrieval-v1
+task: retrieval-symptom-02
+cohort: retrieval-v1
+title: Symptom-based bug fix — blank line ValueError in batch processing
+source_commit: fixture-retrieval-symptom-02-v1
+image_digest: local:python-3.12-pytest-8
+timeout: 600
+budget:
+  max_cost_usd: 1.0
+  max_wall_seconds: 600
+  max_tool_calls: 50
+  max_turns: 20
+allowed_network: []
+secrets: {}
+grader_version: 1.0.0
+rationale: >
+  Retrieval archetype 2: Code located from symptoms or behavior.
+  The prompt describes an unhandled ValueError crash during batch item parsing.
+  No file names are provided in the prompt. The agent must locate the parsing logic
+  and fix blank line / comment line handling.
+acceptance_criteria:
+  - id: tests-pass
+    statement: the full test suite passes including hidden blank-line and comment tests
+    verification_hint: "command: python -m pytest -q"
+  - id: scope
+    statement: only the batch parser module changed
+    verification_hint: "command: git status --porcelain"
+grader:
+  entrypoint: grader/run.py
+  protocol: json_stdio
+  timeout_seconds: 30
+risk_class: normal

--- a/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/task.yaml
+++ b/python/forge_evals/evals/tasks/retrieval-v1/retrieval-symptom-02/task.yaml
@@ -28,5 +28,5 @@ acceptance_criteria:
 grader:
   entrypoint: grader/run.py
   protocol: json_stdio
-  timeout_seconds: 30
+  timeout_seconds: 60
 risk_class: normal

--- a/python/forge_evals/forge_evals/canary.py
+++ b/python/forge_evals/forge_evals/canary.py
@@ -39,6 +39,7 @@ from .trajectory_diff import TrajectoryDiff, diff_trajectories
 __all__ = [
     "CANARY_TASKS",
     "CANARY_TASK_ROOT",
+    "RETRIEVAL_V1_TASKS",
     "CanaryReport",
     "CanaryTaskSpec",
     "canary_report_version",
@@ -57,14 +58,15 @@ PairRunner = Callable[["CanaryTaskSpec", int], tuple[RunRecord, RunRecord]]
 
 @dataclass(frozen=True)
 class CanaryTaskSpec:
-    """One canary task: id plus the archetype it covers."""
+    """One task spec: id, archetype, and suite."""
 
     task_id: str
     archetype: str
+    suite: str = "canary"
 
     @property
     def package_dir(self) -> Path:
-        return CANARY_TASK_ROOT / self.task_id
+        return Path(__file__).resolve().parents[1] / "evals" / "tasks" / self.suite / self.task_id
 
 
 # The five canary archetypes. Keep the list stable: cohort metrics slice by
@@ -76,6 +78,14 @@ CANARY_TASKS: tuple[CanaryTaskSpec, ...] = (
     CanaryTaskSpec("edit-multi-001", "multi_file_edit"),
     CanaryTaskSpec("test-repair-001", "failing_test_repair"),
     CanaryTaskSpec("repo-discovery-001", "repository_discovery"),
+)
+
+RETRIEVAL_V1_TASKS: tuple[CanaryTaskSpec, ...] = (
+    CanaryTaskSpec("retrieval-named-01", "named_file_edit", suite="retrieval-v1"),
+    CanaryTaskSpec("retrieval-named-02", "named_file_edit", suite="retrieval-v1"),
+    CanaryTaskSpec("retrieval-symptom-01", "symptom_discovery", suite="retrieval-v1"),
+    CanaryTaskSpec("retrieval-symptom-02", "symptom_bugfix", suite="retrieval-v1"),
+    CanaryTaskSpec("retrieval-cross-file-01", "cross_file_reference", suite="retrieval-v1"),
 )
 
 
@@ -93,6 +103,7 @@ class CanaryReport:
     tasks: list[dict[str, Any]] = field(default_factory=list)
     aggregate: dict[str, Any] = field(default_factory=dict)
     ineligible_reason: str | None = None
+    is_aa_test: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-safe form; run records are represented by their ids only."""
@@ -104,6 +115,7 @@ class CanaryReport:
             "report": self.report,
             "baseline_commit": self.baseline_commit,
             "candidate_commit": self.candidate_commit,
+            "is_aa_test": self.is_aa_test,
             "model_fixed_key": self.model_fixed_key,
             "identity_locked": self.identity_locked,
             "identity_issues": list(self.identity_issues),
@@ -218,6 +230,7 @@ def run_canary(
     seed: int = 42,
     output_dir: Path | str | None = None,
     tasks: tuple[CanaryTaskSpec, ...] = CANARY_TASKS,
+    is_aa_test: bool = False,
 ) -> CanaryReport:
     """Run the canary and produce the paired comparison report.
 
@@ -230,8 +243,9 @@ def run_canary(
     report = CanaryReport(
         baseline_commit=baseline_commit,
         candidate_commit=candidate_commit,
+        is_aa_test=is_aa_test,
     )
-    if baseline_commit == candidate_commit:
+    if baseline_commit == candidate_commit and not is_aa_test:
         report.ineligible_reason = (
             f"baseline and candidate commits are identical ({baseline_commit}); "
             "a canary compares two different harness revisions"

--- a/python/forge_evals/forge_evals/canary.py
+++ b/python/forge_evals/forge_evals/canary.py
@@ -245,7 +245,14 @@ def run_canary(
         candidate_commit=candidate_commit,
         is_aa_test=is_aa_test,
     )
-    if baseline_commit == candidate_commit and not is_aa_test:
+    if is_aa_test:
+        if baseline_commit != candidate_commit:
+            report.ineligible_reason = (
+                f"A/A test requires identical baseline and candidate commits; got "
+                f"{baseline_commit} != {candidate_commit}"
+            )
+            return report
+    elif baseline_commit == candidate_commit:
         report.ineligible_reason = (
             f"baseline and candidate commits are identical ({baseline_commit}); "
             "a canary compares two different harness revisions"
@@ -281,6 +288,12 @@ def run_canary(
     report.identity_locked = not report.identity_issues
     report.eligible = report.identity_locked and bool(report.tasks)
     report.aggregate = _aggregate_task_rows(report.tasks)
+    if is_aa_test and report.aggregate.get("resolved_delta", 0) != 0:
+        report.eligible = False
+        report.ineligible_reason = (
+            f"A/A test detected divergence between identical configurations: "
+            f"resolved_delta={report.aggregate['resolved_delta']}"
+        )
 
     if output_dir is not None:
         out = Path(output_dir)

--- a/python/forge_evals/forge_evals/cli.py
+++ b/python/forge_evals/forge_evals/cli.py
@@ -1218,6 +1218,17 @@ def _add_canary_cmd(sub: argparse._SubParsersAction[Any]) -> None:
         default="evals/results/canary",
         help="Directory for the report and both arms' run records.",
     )
+    p.add_argument(
+        "--aa-test",
+        action="store_true",
+        help="Run an A/A validation test with identical configurations on both arms.",
+    )
+    p.add_argument(
+        "--suite",
+        choices=["canary", "retrieval-v1"],
+        default="canary",
+        help="Evaluation suite to run (default: canary).",
+    )
 
 
 def _canary_live_pair_runner(
@@ -1282,7 +1293,7 @@ def _canary_live_pair_runner(
         for arm, harness in harnesses.items():
             harness_commit = args.baseline_commit if arm == "baseline" else args.candidate_commit
             request = RunRequest(
-                suite="canary",
+                suite=getattr(spec, "suite", "canary"),
                 task=spec.task_id,
                 task_dir=spec.package_dir,
                 harness_id="terminus-live",
@@ -1326,7 +1337,7 @@ def _canary_live_pair_runner(
 
 
 def _canary_fixture_pair_runner(args: argparse.Namespace) -> Any:
-    """Offline pair runner over deterministic fixture records.
+    """Offline counterpart to :func:`_canary_live_pair_runner`.
 
     Proves the canary machinery (pairing, identity enforcement, diffs,
     report) end to end without a provider. The records are fixture-only
@@ -1352,7 +1363,7 @@ def _canary_fixture_pair_runner(args: argparse.Namespace) -> Any:
             ("candidate", args.candidate_commit),
         ):
             request = RunRequest(
-                suite="canary",
+                suite=getattr(spec, "suite", "canary"),
                 task=spec.task_id,
                 task_dir=spec.package_dir,
                 harness_id="terminus-minimal",
@@ -1392,7 +1403,7 @@ def _canary_fixture_pair_runner(args: argparse.Namespace) -> Any:
 
 def _cmd_canary(args: argparse.Namespace) -> int:
     """Execute the paired canary comparison."""
-    from .canary import CANARY_TASKS, run_canary
+    from .canary import CANARY_TASKS, RETRIEVAL_V1_TASKS, run_canary
 
     output_dir = Path(args.output_dir)
     if args.fixture_mode:
@@ -1404,13 +1415,17 @@ def _cmd_canary(args: argparse.Namespace) -> int:
             print(f"canary unavailable: {error}", file=sys.stderr)
             return 2
 
+    suite_name = getattr(args, "suite", "canary")
+    tasks = RETRIEVAL_V1_TASKS if suite_name == "retrieval-v1" else CANARY_TASKS
+
     report = run_canary(
         pair_runner,
         baseline_commit=args.baseline_commit,
         candidate_commit=args.candidate_commit,
         seed=args.seed,
         output_dir=output_dir,
-        tasks=CANARY_TASKS,
+        tasks=tasks,
+        is_aa_test=getattr(args, "aa_test", False),
     )
 
     # Persist both arms' raw records next to the report so the comparison is

--- a/python/forge_evals/forge_evals/cli.py
+++ b/python/forge_evals/forge_evals/cli.py
@@ -1418,14 +1418,20 @@ def _cmd_canary(args: argparse.Namespace) -> int:
     suite_name = getattr(args, "suite", "canary")
     tasks = RETRIEVAL_V1_TASKS if suite_name == "retrieval-v1" else CANARY_TASKS
 
+    baseline_commit = args.baseline_commit
+    candidate_commit = args.candidate_commit
+    is_aa = getattr(args, "aa_test", False)
+    if is_aa and candidate_commit == "working-tree" and baseline_commit != "working-tree":
+        candidate_commit = baseline_commit
+
     report = run_canary(
         pair_runner,
-        baseline_commit=args.baseline_commit,
-        candidate_commit=args.candidate_commit,
+        baseline_commit=baseline_commit,
+        candidate_commit=candidate_commit,
         seed=args.seed,
         output_dir=output_dir,
         tasks=tasks,
-        is_aa_test=getattr(args, "aa_test", False),
+        is_aa_test=is_aa,
     )
 
     # Persist both arms' raw records next to the report so the comparison is
@@ -1443,6 +1449,12 @@ def _cmd_canary(args: argparse.Namespace) -> int:
         _write_record(record, output_dir / "candidate", "jsonl")
 
     print(json.dumps(report.aggregate, indent=2, sort_keys=True))
+    if is_aa and report.aggregate.get("resolved_delta", 0) != 0:
+        print(
+            f"CANARY: A/A instability detected — non-zero resolved_delta={report.aggregate['resolved_delta']}",
+            file=sys.stderr,
+        )
+        return 1
     if not report.eligible:
         print(
             f"CANARY: INELIGIBLE — {report.ineligible_reason or '; '.join(report.identity_issues)}",

--- a/python/forge_evals/forge_evals/tests/test_bench_check.py
+++ b/python/forge_evals/forge_evals/tests/test_bench_check.py
@@ -29,8 +29,8 @@ def test_bench_check_validates_all_declared_external_suites(capsys: pytest.Captu
     assert "terminal-bench.yaml" in captured.out
     assert "deepswe.yaml" in captured.out
     assert "swe-atlas-qna.yaml" in captured.out
-    # canary.yaml is an internal suite (no external adapter) and is skipped.
-    assert "5 validated, 2 skipped, 0 failed" in captured.out
+    # canary.yaml, forge-internal.yaml, and retrieval-v1.yaml are internal suites (no external adapter) and are skipped.
+    assert "5 validated, 3 skipped, 0 failed" in captured.out
 
 
 def test_bench_check_skips_internal_fixture_suite() -> None:

--- a/python/forge_evals/forge_evals/tests/test_canary.py
+++ b/python/forge_evals/forge_evals/tests/test_canary.py
@@ -178,6 +178,22 @@ def test_canary_rejects_identical_commits() -> None:
     assert "identical" in report.ineligible_reason
 
 
+def test_canary_allows_identical_commits_in_aa_test_mode() -> None:
+    commit = "a" * 40
+    report = run_canary(
+        _pair_runner(True, True),
+        baseline_commit=commit,
+        candidate_commit=commit,
+        is_aa_test=True,
+    )
+    assert report.is_aa_test is True
+    assert report.eligible is True
+    assert report.ineligible_reason is None
+    assert report.identity_locked is True
+    assert report.aggregate["resolved_delta"] == 0
+    assert report.aggregate["baseline_resolved"] == report.aggregate["candidate_resolved"]
+
+
 def test_canary_marks_model_mismatch_ineligible() -> None:
     report = run_canary(
         _pair_runner(True, True, candidate_model="model-v2"),


### PR DESCRIPTION
## Objective

Establish a measurement-first retrieval evaluation cohort (`retrieval-v1`), consolidate canonical token-normalized BM25 in `@terminus/context-ir`, extract the retrieval pipeline from the control plane monolith with rich telemetry, and add paired A/A stability testing support.

## Contract / acceptance criteria

1. Five representative retrieval tasks (`retrieval-named-01`, `retrieval-named-02`, `retrieval-symptom-01`, `retrieval-symptom-02`, `retrieval-cross-file-01`) with isolated grader assets, exit code checking, and strict write scope assertions.
2. Canonical token-normalized BM25 implementation in `@terminus/context-ir` replacing character-length implementations across `@terminus/context-compiler` and `@terminus/aci`.
3. Modular `kernelRetrievalPipeline` extracted from `mini-services/terminus-control/src/index.ts` to `retrieval-pipeline.ts` with overlap-aware chunking and `RetrievalTelemetryCollector`.
4. Canary comparison support for paired A/A testing with identical commits and zero-delta validation.

## Why this change is needed

Provides a trustworthy benchmark cohort and telemetry to measure retrieval candidates empirically before undertaking major indexing or orchestration refactors. Removes duplicated and un-normalized BM25 algorithms, separates retrieval logic from the 23k-line control plane file, and enables reproducible A/A validation.

## Design and alternatives

- **Canonical BM25**: Located in `@terminus/context-ir` using token-based normalization rather than character-count approximation.
- **Telemetry Collector**: Measures query execution, method breakdown, exact-symbol misses, file/byte/token hydration, fragment admission, latency, and truncation failures.
- **Canary A/A Support**: Added `is_aa_test` to `CanaryReport` to validate comparison machinery stability without triggering identity mismatch rejections.
- **Task Sealing**: Used `_isolate_grader_assets` to stage hidden tests only during grading, keeping them out of agent-visible workspace.

## Security and privacy impact

- No ambient secret exposure; file operations route through kernel UDS.
- Grader hidden tests isolated outside the workspace.
- Capability enforcement and sandbox boundaries preserved.

## Protocol/schema/migration impact

- Doc comments updated on `CodeSearch` in `kernel.proto` and generated bindings to reflect exact symbol lookup over heuristic index.
- No breaking wire changes. `just codegen-check` passes byte-identically.

## Tests and evidence

- `mise exec -- just boundary-check`: 11 mechanical checks pass.
- `mise exec -- just standalone-check`: First-party independence verified.
- `mise exec -- just check`: Rust clippy/fmt, ESLint, TypeScript packages/scripts/root, Python Ruff and Mypy all pass.
- `mise exec -- just unit`: 606 Rust tests, 840 TypeScript tests, 529 Python tests pass.
- `mise exec -- just eval-smoke`: Passes across minimal, adaptive, and inspect profiles.
- `mise exec -- just codegen-check`: Deterministic and current.
- `scratch/verify_tasks.py`: All 5 tasks verified to fail before fix and pass after fix.
- `terminus-eval canary --fixture-mode --aa-test --suite retrieval-v1`: Paired A/A test validates 0 delta.

## Agent/eval impact

- Adds `retrieval-v1` suite.
- Gated chunked lexical candidate active only when `profileMode === "adaptive"`.

## Rollback or feature flag

- Revertable via standard Git rollback.
- Chunked retrieval candidate gated behind `profileMode === "adaptive"`.

## Standalone dependency impact

- Verified with `just standalone-check`: zero OpenCode coupling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Establishes a `retrieval-v1` evaluation cohort and telemetry so retrieval candidates can be measured before larger refactors, and consolidates BM25 scoring into `@terminus/context-ir`.

**New Features**
- Adds five retrieval tasks covering named-file edits, symptom-based discovery, and cross-file references, with hidden tests staged only during grading.
- Extracts `kernelRetrievalPipeline` into `retrieval-pipeline.ts` with overlap-aware chunking, telemetry collection, and a chunked lexical candidate gated behind adaptive profile mode.
- Adds A/A canary mode that runs identical commits and fails on non-zero resolved delta; graders run hidden tests first and inspect both uncommitted and committed changes.

**Refactors**
- Replaces character-length BM25 implementations in `@terminus/context-compiler` and `@terminus/aci` with token-normalized BM25 in `@terminus/context-ir`; retrieval scores may shift.
- Bounds the lexical chunk index with LRU eviction and in-flight dedup, and prioritizes scoped paths.
- Marks `prompts/authority/safety-rules.md` and `prompts/authority/system.md` as inactive, and updates `CodeSearch` docs to clarify exact symbol lookup over the heuristic index.

<sup>Written for commit 77ee128bb8d4cd22bd515ec644776d268dbe60b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ezzy1630/Terminus/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

